### PR TITLE
Markdown parse fixes, max content width

### DIFF
--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -211,6 +211,8 @@ const bottomLinks: Link[] = [
     padding: var(--default-padding);
     padding-top: 5em;
     padding-bottom: 5em;
+    max-width: var(--content-max-width);
+    margin: 0 auto;
   }
 
   .grid {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,6 +75,8 @@ const title = Astro.props.title;
   main {
     padding: var(--default-padding);
     flex: 1;
+    max-width: var(--content-max-width); /* this is so that on very large screens content doesn't stretch too wide. */
+    margin: 0 auto;
   }
 
   @media (max-width: 600px) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -75,8 +75,13 @@ const title = Astro.props.title;
   main {
     padding: var(--default-padding);
     flex: 1;
-    max-width: var(--content-max-width); /* this is so that on very large screens content doesn't stretch too wide. */
-    margin: 0 auto;
+  }
+
+  @media (min-width: 1920px) {
+    main {
+      width: var(--content-max-width);
+      margin: 0 auto;
+    }
   }
 
   @media (max-width: 600px) {

--- a/src/pages/resources/moneropedia/index.astro
+++ b/src/pages/resources/moneropedia/index.astro
@@ -71,7 +71,7 @@ for (const letter of sortedLetters) {
 
           const accordionItems = groupEntries.map((entry) => ({
             title: entry.title,
-            content: safeMarkdown.parseInline(
+            content: safeMarkdown.parse(
               `${entry.data.summary}\n\n[${t("moneropedia.readMore")} ](${entry.href})`,
             ),
           }));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,6 +42,9 @@
   --line-height-body: 1.6;
   --line-height-heading: 1.1;
   --line-height-title: 1.2;
+
+  /* Maximum Content Width */
+  --content-max-width: 1920px;
 }
 
 /* ========================================


### PR DESCRIPTION
* Added a new CSS variable `--content-max-width` set to `1920px` in `global.css` to standardize the maximum width of main content across the site.
* Updated the `Footer.astro` and `Layout.astro` components to use the new `--content-max-width` variable and center content horizontally, ensuring a consistent and visually appealing layout on large screens.
* Patch for moneropedia markdown parsing