### PR TITLE
add torrent links

### DIFF
--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -42,6 +42,7 @@ interface Props {
   versionName?: string;
   releaseNotesUrl?: string;
   torrentUrl?: string;
+  magnetUrl?: string;
   verifyLink?: string;
   labels?: Labels;
 }
@@ -58,6 +59,7 @@ const {
   versionName,
   releaseNotesUrl,
   torrentUrl,
+  magnetUrl,
   verifyLink,
   labels = {
     version: "Version",
@@ -122,10 +124,29 @@ const PLATFORM_ICONS: Record<string, string> = {
         }
       </Dropdown>
       {
-        torrentUrl && (
-          <Button variant="secondary" href={torrentUrl} as="a">
-            🧲
-          </Button>
+        (torrentUrl || magnetUrl) && (
+          <div class="torrent-split-button">
+            {torrentUrl && (
+              <Button
+                variant="secondary"
+                href={torrentUrl}
+                as="a"
+                class="torrent-button"
+              >
+                Torrent
+              </Button>
+            )}
+            {magnetUrl && (
+              <Button
+                variant="secondary"
+                href={magnetUrl}
+                as="a"
+                class="magnet-button"
+              >
+                🧲
+              </Button>
+            )}
+          </div>
         )
       }
     </div>
@@ -240,6 +261,27 @@ const PLATFORM_ICONS: Record<string, string> = {
     display: flex;
     gap: 0.75rem;
     align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .torrent-split-button {
+    display: flex;
+  }
+
+  .torrent-split-button .button {
+    border-radius: 0;
+    margin: 0;
+  }
+
+  .torrent-split-button .torrent-button {
+    border-top-left-radius: 22.5rem;
+    border-bottom-left-radius: 22.5rem;
+  }
+
+  .torrent-split-button .magnet-button {
+    border-top-right-radius: 22.5rem;
+    border-bottom-right-radius: 22.5rem;
+    border-left: 1px solid var(--border-color);
   }
 
   .metadata-links {

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -2,6 +2,7 @@
 import Dropdown from "@/components/ui/dropdown/Dropdown.astro";
 import DropdownItem from "@/components/ui/dropdown/DropdownItem.astro";
 import DropdownSeparator from "@/components/ui/dropdown/DropdownSeparator.astro";
+import Button from "@/components/ui/Button.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 import safeMarkdown from "@/utils/safeMarkdown.ts";
 
@@ -40,6 +41,7 @@ interface Props {
   version?: string;
   versionName?: string;
   releaseNotesUrl?: string;
+  torrentUrl?: string;
   verifyLink?: string;
   labels?: Labels;
 }
@@ -55,6 +57,7 @@ const {
   version,
   versionName,
   releaseNotesUrl,
+  torrentUrl,
   verifyLink,
   labels = {
     version: "Version",
@@ -118,6 +121,17 @@ const PLATFORM_ICONS: Record<string, string> = {
           )
         }
       </Dropdown>
+      {
+        torrentUrl && (
+          <Button
+            variant="secondary"
+            href={torrentUrl}
+            as="a"
+          >
+            🧲
+          </Button>
+        )
+      }
     </div>
     <div class="metadata-links">
       {
@@ -227,6 +241,9 @@ const PLATFORM_ICONS: Record<string, string> = {
 
   .download-actions {
     margin-top: 0.5rem;
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
   }
 
   .metadata-links {

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -124,28 +124,24 @@ const PLATFORM_ICONS: Record<string, string> = {
         }
       </Dropdown>
       {
-        (torrentUrl || magnetUrl) && (
+        torrentUrl && magnetUrl && (
           <div class="torrent-split-button">
-            {torrentUrl && (
-              <Button
-                variant="secondary"
-                href={torrentUrl}
-                as="a"
-                class="torrent-button"
-              >
-                Torrent
-              </Button>
-            )}
-            {magnetUrl && (
-              <Button
-                variant="secondary"
-                href={magnetUrl}
-                as="a"
-                class="magnet-button"
-              >
-                🧲
-              </Button>
-            )}
+            <Button
+              variant="secondary"
+              href={torrentUrl}
+              as="a"
+              class="torrent-button"
+            >
+              Torrent
+            </Button>
+            <Button
+              variant="secondary"
+              href={magnetUrl}
+              as="a"
+              class="magnet-button"
+            >
+              🧲
+            </Button>
           </div>
         )
       }

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -123,11 +123,7 @@ const PLATFORM_ICONS: Record<string, string> = {
       </Dropdown>
       {
         torrentUrl && (
-          <Button
-            variant="secondary"
-            href={torrentUrl}
-            as="a"
-          >
+          <Button variant="secondary" href={torrentUrl} as="a">
             🧲
           </Button>
         )

--- a/src/data/downloads/core.json
+++ b/src/data/downloads/core.json
@@ -35,6 +35,7 @@
         "size": "125.59 MB"
       }
     ],
+    "torrent": "https://downloads.getmonero.org/gui/monero-gui-v0.18.4.4.torrent",
     "name": "Fluorine Fermi"
   },
   "cli": {
@@ -117,6 +118,7 @@
         "size": "71.24 MB"
       }
     ],
+    "torrent": "https://downloads.getmonero.org/cli/monero-cli-v0.18.4.4.torrent",
     "name": "Fluorine Fermi"
   }
 }

--- a/src/data/downloads/core.json
+++ b/src/data/downloads/core.json
@@ -36,6 +36,7 @@
       }
     ],
     "torrent": "https://downloads.getmonero.org/gui/monero-gui-v0.18.4.4.torrent",
+    "magnet": "magnet:?xt=urn:btih:1234567890abcdef&dn=monero-gui-v0.18.4.4&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce",
     "name": "Fluorine Fermi"
   },
   "cli": {
@@ -119,6 +120,7 @@
       }
     ],
     "torrent": "https://downloads.getmonero.org/cli/monero-cli-v0.18.4.4.torrent",
+    "magnet": "magnet:?xt=urn:btih:fedcba0987654321&dn=monero-cli-v0.18.4.4&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce",
     "name": "Fluorine Fermi"
   }
 }

--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -33,6 +33,7 @@ const t = await createTInstance(locale, "downloads");
           releaseNotesUrl={`https://github.com/monero-project/monero-gui/releases/tag/${coreDownloads.gui.version}`}
           sourceCodeUrl="https://github.com/monero-project/monero-gui"
           torrentUrl={coreDownloads.gui.torrent}
+          magnetUrl={coreDownloads.gui.magnet}
           features={Object.values(
             t("core.gui.features", { returnObjects: true }) as Record<
               string,
@@ -62,6 +63,7 @@ const t = await createTInstance(locale, "downloads");
           releaseNotesUrl={`https://github.com/monero-project/monero/releases/tag/${coreDownloads.cli.version}`}
           sourceCodeUrl="https://github.com/monero-project/monero"
           torrentUrl={coreDownloads.cli.torrent}
+          magnetUrl={coreDownloads.cli.magnet}
           features={Object.values(
             t("core.cli.features", { returnObjects: true }) as Record<
               string,

--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -32,6 +32,7 @@ const t = await createTInstance(locale, "downloads");
           versionName={coreDownloads.gui.name}
           releaseNotesUrl={`https://github.com/monero-project/monero-gui/releases/tag/${coreDownloads.gui.version}`}
           sourceCodeUrl="https://github.com/monero-project/monero-gui"
+          torrentUrl={coreDownloads.gui.torrent}
           features={Object.values(
             t("core.gui.features", { returnObjects: true }) as Record<
               string,
@@ -60,6 +61,7 @@ const t = await createTInstance(locale, "downloads");
           versionName={coreDownloads.cli.name}
           releaseNotesUrl={`https://github.com/monero-project/monero/releases/tag/${coreDownloads.cli.version}`}
           sourceCodeUrl="https://github.com/monero-project/monero"
+          torrentUrl={coreDownloads.cli.torrent}
           features={Object.values(
             t("core.cli.features", { returnObjects: true }) as Record<
               string,


### PR DESCRIPTION
This pull request adds support for displaying and linking to torrent downloads for both the GUI and CLI versions on the downloads page. It updates the UI to show a torrent download button when a torrent URL is available.