### PR TITLE
Cleanup and organize

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,8 @@
 // @ts-check
-import { defineConfig } from "astro/config";
 import sitemap from "@astrojs/sitemap";
-import { i18n, filterSitemapByDefaultLocale } from "astro-i18n-aut/integration";
+import { filterSitemapByDefaultLocale, i18n } from "astro-i18n-aut/integration";
+import { defineConfig } from "astro/config";
+
 import { defaultLocale, locales } from "./src/i18n/config";
 
 // https://astro.build/config

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,9 @@
 // @ts-check
-
 import js from "@eslint/js";
+import eslintConfigPrettier from "eslint-config-prettier/flat";
+import eslintPluginAstro from "eslint-plugin-astro";
 import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
-import eslintPluginAstro from "eslint-plugin-astro";
-import eslintConfigPrettier from "eslint-config-prettier/flat";
 
 export default defineConfig([
   {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "htmlhint": "^1.7.1",
     "prettier": "3.6.2",
     "prettier-plugin-astro": "0.14.1",
+    "prettier-plugin-astro-organize-imports": "^0.4.11",
     "sass": "^1.94.1",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       prettier-plugin-astro:
         specifier: 0.14.1
         version: 0.14.1
+      prettier-plugin-astro-organize-imports:
+        specifier: ^0.4.11
+        version: 0.4.11(prettier-plugin-astro@0.14.1)(prettier@3.6.2)
       sass:
         specifier: ^1.94.1
         version: 1.94.1
@@ -2278,6 +2281,18 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-astro-organize-imports@0.4.11:
+    resolution: {integrity: sha512-qJQZ7qgnTVmk8ALe1SXpCVGa2QNanhsKn6ivfGQqWH8SCgQY1/poxLVras0Q4fqRBugR3xPRGxovODk1tmkbwA==}
+    peerDependencies:
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-tailwindcss: '*'
+    peerDependenciesMeta:
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-tailwindcss:
+        optional: true
 
   prettier-plugin-astro@0.14.1:
     resolution: {integrity: sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==}
@@ -5699,6 +5714,14 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-astro-organize-imports@0.4.11(prettier-plugin-astro@0.14.1)(prettier@3.6.2):
+    dependencies:
+      '@astrojs/compiler': 2.13.0
+      prettier: 3.6.2
+      typescript: 5.9.3
+    optionalDependencies:
+      prettier-plugin-astro: 0.14.1
 
   prettier-plugin-astro@0.14.1:
     dependencies:

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import("prettier").Config} */
 export default {
   // Astro formatting
-  plugins: ["prettier-plugin-astro"],
+  plugins: ["prettier-plugin-astro", "prettier-plugin-astro-organize-imports"],
   overrides: [
     {
       files: "*.astro",

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,8 +1,10 @@
 ---
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import externalLink from "@/assets/icons/mask/external-link.avif?url";
+import { getDirection, localizeHref } from "@/i18n/utils";
 import { getLocale } from "astro-i18n-aut";
-import { localizeHref, getDirection } from "@/i18n/utils";
+
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import externalLink from "@/assets/icons/mask/external-link.avif?url";
 
 const { t } = Astro.props;
 const locale = getLocale(Astro.url);

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -270,10 +270,6 @@ const bottomLinks: Link[] = [
     justify-content: center;
   }
 
-  .inline-item a {
-    color: var(--footer-muted);
-  }
-
   .inline-item a:hover,
   .inline-item a:focus {
     color: var(--heading-color);
@@ -292,9 +288,6 @@ const bottomLinks: Link[] = [
   @media (max-width: 560px) {
     .grid {
       grid-template-columns: 1fr;
-    }
-    .wrap {
-      padding: 40px 16px 22px;
     }
   }
 </style>

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -195,7 +195,7 @@ const navItems = [
         alt=""
         aria-hidden="true"
       />
-      <span class="word">MONERO</span>
+      <span>MONERO</span>
     </a>
 
     <input
@@ -271,14 +271,8 @@ const navItems = [
   }
 
   .mark {
-    display: grid;
-    place-items: center;
     inline-size: 1.625rem;
     block-size: 1.625rem;
-  }
-
-  .nav {
-    justify-self: center;
   }
 
   .nav-list {

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,46 +1,47 @@
 ---
-import NavItem from "@/components/ui/header/NavItem.astro";
-import LanguageDropdown from "@/components/ui/header/LanguageDropdown.astro";
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getLocale } from "astro-i18n-aut";
 import { localizeHref } from "@/i18n/utils";
+import { getLocale } from "astro-i18n-aut";
 
-import hamburger from "@/assets/icons/mask/hamburger.avif?url";
+import LanguageDropdown from "@/components/ui/header/LanguageDropdown.astro";
+import NavItem from "@/components/ui/header/NavItem.astro";
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
 import close from "@/assets/icons/mask/close.avif?url";
+import hamburger from "@/assets/icons/mask/hamburger.avif?url";
 
-import whatIsMonero from "@/assets/icons/color/light/what-is-monero.avif?url";
 import acceptMonero from "@/assets/icons/color/light/accept-monero.avif?url";
 import contribute from "@/assets/icons/color/light/contribute.avif?url";
-import mining from "@/assets/icons/color/light/mining.avif?url";
+import developerGuides from "@/assets/icons/color/light/developer-guides.avif?url";
 import faq from "@/assets/icons/color/light/faq.avif?url";
-import workgroups from "@/assets/icons/color/light/workgroups.avif?url";
-import sponsorships from "@/assets/icons/color/light/sponsorships.avif?url";
 import hangouts from "@/assets/icons/color/light/hangouts.avif?url";
 import merchantsExchanges from "@/assets/icons/color/light/merchants-exchanges.avif?url";
+import mining from "@/assets/icons/color/light/mining.avif?url";
 import moneropedia from "@/assets/icons/color/light/moneropedia.avif?url";
-import roadmap from "@/assets/icons/color/light/roadmap.avif?url";
-import researchLab from "@/assets/icons/color/light/research-lab.avif?url";
-import userGuides from "@/assets/icons/color/light/user-guides.avif?url";
-import developerGuides from "@/assets/icons/color/light/developer-guides.avif?url";
-import tools from "@/assets/icons/color/light/tools.avif?url";
 import pressKit from "@/assets/icons/color/light/press-kit.avif?url";
+import researchLab from "@/assets/icons/color/light/research-lab.avif?url";
+import roadmap from "@/assets/icons/color/light/roadmap.avif?url";
+import sponsorships from "@/assets/icons/color/light/sponsorships.avif?url";
+import tools from "@/assets/icons/color/light/tools.avif?url";
+import userGuides from "@/assets/icons/color/light/user-guides.avif?url";
+import whatIsMonero from "@/assets/icons/color/light/what-is-monero.avif?url";
+import workgroups from "@/assets/icons/color/light/workgroups.avif?url";
 
-import whatIsMoneroDark from "@/assets/icons/color/dark/what-is-monero.avif?url";
 import acceptMoneroDark from "@/assets/icons/color/dark/accept-monero.avif?url";
 import contributeDark from "@/assets/icons/color/dark/contribute.avif?url";
-import miningDark from "@/assets/icons/color/dark/mining.avif?url";
+import developerGuidesDark from "@/assets/icons/color/dark/developer-guides.avif?url";
 import faqDark from "@/assets/icons/color/dark/faq.avif?url";
-import workgroupsDark from "@/assets/icons/color/dark/workgroups.avif?url";
-import sponsorshipsDark from "@/assets/icons/color/dark/sponsorships.avif?url";
 import hangoutsDark from "@/assets/icons/color/dark/hangouts.avif?url";
 import merchantsExchangesDark from "@/assets/icons/color/dark/merchants-exchanges.avif?url";
+import miningDark from "@/assets/icons/color/dark/mining.avif?url";
 import moneropediaDark from "@/assets/icons/color/dark/moneropedia.avif?url";
-import roadmapDark from "@/assets/icons/color/dark/roadmap.avif?url";
-import researchLabDark from "@/assets/icons/color/dark/research-lab.avif?url";
-import userGuidesDark from "@/assets/icons/color/dark/user-guides.avif?url";
-import developerGuidesDark from "@/assets/icons/color/dark/developer-guides.avif?url";
-import toolsDark from "@/assets/icons/color/dark/tools.avif?url";
 import pressKitDark from "@/assets/icons/color/dark/press-kit.avif?url";
+import researchLabDark from "@/assets/icons/color/dark/research-lab.avif?url";
+import roadmapDark from "@/assets/icons/color/dark/roadmap.avif?url";
+import sponsorshipsDark from "@/assets/icons/color/dark/sponsorships.avif?url";
+import toolsDark from "@/assets/icons/color/dark/tools.avif?url";
+import userGuidesDark from "@/assets/icons/color/dark/user-guides.avif?url";
+import whatIsMoneroDark from "@/assets/icons/color/dark/what-is-monero.avif?url";
+import workgroupsDark from "@/assets/icons/color/dark/workgroups.avif?url";
 
 const { t } = Astro.props;
 const locale = getLocale(Astro.url);

--- a/src/components/pages/downloads/CommunityCard.astro
+++ b/src/components/pages/downloads/CommunityCard.astro
@@ -232,7 +232,7 @@ const showPlatforms = desktop.length > 0 || mobile.length > 0;
     padding: 0.25rem 0.5rem;
     border-radius: 999px;
     background: color-mix(in oklab, var(--card-color), black 10%);
-    font-size: var(--font-size-xs, 0.85rem);
+    font-size: 0.85rem;
     color: var(--paragraph-main);
     line-height: 1;
   }

--- a/src/components/pages/downloads/CommunityCard.astro
+++ b/src/components/pages/downloads/CommunityCard.astro
@@ -1,13 +1,13 @@
 ---
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import externalLink from "@/assets/icons/mask/external-link.avif?url";
-
-import windowsIcon from "@/assets/icons/mask/brand/windows.avif?url";
-import linuxIcon from "@/assets/icons/mask/brand/linux.avif?url";
-import appleIcon from "@/assets/icons/mask/brand/apple.avif?url";
-import androidIcon from "@/assets/icons/mask/brand/android.avif?url";
-
 import { getDirection, getLocale } from "@/i18n/utils";
+
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import androidIcon from "@/assets/icons/mask/brand/android.avif?url";
+import appleIcon from "@/assets/icons/mask/brand/apple.avif?url";
+import linuxIcon from "@/assets/icons/mask/brand/linux.avif?url";
+import windowsIcon from "@/assets/icons/mask/brand/windows.avif?url";
+import externalLink from "@/assets/icons/mask/external-link.avif?url";
 
 interface Tags {
   desktop?: string[]; // windows | macos | linux (aliases: win, mac, osx)

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -1,18 +1,19 @@
 ---
+import safeMarkdown from "@/utils/safeMarkdown.ts";
+
+import Button from "@/components/ui/Button.astro";
+import ColorIcon from "@/components/ui/ColorIcon.astro";
 import Dropdown from "@/components/ui/dropdown/Dropdown.astro";
 import DropdownItem from "@/components/ui/dropdown/DropdownItem.astro";
 import DropdownSeparator from "@/components/ui/dropdown/DropdownSeparator.astro";
-import Button from "@/components/ui/Button.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import safeMarkdown from "@/utils/safeMarkdown.ts";
 
-import windowsIcon from "@/assets/icons/mask/brand/windows.avif?url";
-import linuxIcon from "@/assets/icons/mask/brand/linux.avif?url";
+import magnetIcon from "@/assets/icons/color/magnet.avif?url";
+import androidIcon from "@/assets/icons/mask/brand/android.avif?url";
 import appleIcon from "@/assets/icons/mask/brand/apple.avif?url";
 import freebsdIcon from "@/assets/icons/mask/brand/freebsd.avif?url";
-import androidIcon from "@/assets/icons/mask/brand/android.avif?url";
-import ColorIcon from "@/components/ui/ColorIcon.astro";
-import magnetIcon from "@/assets/icons/color/magnet.avif?url";
+import linuxIcon from "@/assets/icons/mask/brand/linux.avif?url";
+import windowsIcon from "@/assets/icons/mask/brand/windows.avif?url";
 
 export interface DownloadLink {
   href: string;

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -99,8 +99,7 @@ const PLATFORM_ICONS: Record<string, string> = {
                     </span>
                   )}
                   <span>
-                    {t(`platforms.${item.platform}`)} (
-                    {t(`core.formats.${item.format}`)})
+                    {`${t(`platforms.${item.platform}`)} (${t(`core.formats.${item.format}`)})`}
                   </span>
                 </span>
                 {item.size && <span slot="meta">{item.size}</span>}

--- a/src/components/pages/index/GetStartedCard.astro
+++ b/src/components/pages/index/GetStartedCard.astro
@@ -1,8 +1,10 @@
 ---
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
-import { localizeHref, getDirection, localizeNumber } from "@/i18n/utils";
+import { getDirection, localizeHref, localizeNumber } from "@/i18n/utils";
 import { getLocale } from "astro-i18n-aut";
+
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
 
 export interface Props {
   step: string | number;

--- a/src/components/pages/index/Hero.astro
+++ b/src/components/pages/index/Hero.astro
@@ -1,10 +1,13 @@
 ---
 import { getLocale, localizeHref } from "@/i18n/utils";
+
+import Button from "@/components/ui/Button.astro";
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import moneroOutline from "@/assets/icons/mask/monerooutline.avif?url";
+
 const { t } = Astro.props;
 const locale = getLocale(Astro.url);
-import moneroOutline from "@/assets/icons/mask/monerooutline.avif?url";
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import Button from "@/components/ui/Button.astro";
 ---
 
 <div class="hero" aria-labelledby="hero-title">

--- a/src/components/pages/index/ResourceCard.astro
+++ b/src/components/pages/index/ResourceCard.astro
@@ -1,6 +1,10 @@
 ---
-import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
+import { getDirection, getLocale } from "@/i18n/utils";
+
 import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
+
 export interface Props {
   icon?: string;
   title: string;
@@ -8,7 +12,6 @@ export interface Props {
   ctaLabel?: string;
   ctaHref?: string;
 }
-import { getDirection, getLocale } from "@/i18n/utils";
 
 const {
   icon = null,

--- a/src/components/pages/moneropedia/MoneropediaContent.astro
+++ b/src/components/pages/moneropedia/MoneropediaContent.astro
@@ -1,10 +1,10 @@
 ---
+import "@/styles/moneropedia-link.css";
 import {
   getMoneropediaEntries,
   processMoneropediaLinks,
 } from "@/utils/moneropedia";
 import DOMPurify from "isomorphic-dompurify";
-import "@/styles/moneropedia-link.css";
 
 interface Props {
   locale: string;

--- a/src/components/ui/Accordion.astro
+++ b/src/components/ui/Accordion.astro
@@ -1,9 +1,9 @@
 ---
 import "node:crypto";
 
-import MaskIcon from "./MaskIcon.astro";
 import dropdownIcon from "@/assets/icons/mask/dropdown-caret.avif?url";
 import DOMPurify from "isomorphic-dompurify";
+import MaskIcon from "./MaskIcon.astro";
 
 export interface AccordionItem {
   title: string;

--- a/src/components/ui/Button.astro
+++ b/src/components/ui/Button.astro
@@ -1,6 +1,6 @@
 ---
-type Variant = "primary" | "secondary" | "outline" | "danger";
 type As = "button" | "a" | "span";
+type Variant = "primary" | "secondary" | "outline" | "danger";
 
 interface Props {
   variant?: Variant;

--- a/src/components/ui/dropdown/Dropdown.astro
+++ b/src/components/ui/dropdown/Dropdown.astro
@@ -1,6 +1,7 @@
 ---
 import Button from "@/components/ui/Button.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
+
 import dropdownCaretIcon from "@/assets/icons/mask/dropdown-caret.avif?url";
 
 interface Props {

--- a/src/components/ui/header/LanguageDropdown.astro
+++ b/src/components/ui/header/LanguageDropdown.astro
@@ -1,8 +1,10 @@
 ---
-import { getLocale } from "astro-i18n-aut";
-import { locales, defaultLocale } from "@/i18n/config";
+import { defaultLocale, locales } from "@/i18n/config";
 import { getLocaleName } from "@/i18n/utils";
+import { getLocale } from "astro-i18n-aut";
+
 import MaskIcon from "@/components/ui/MaskIcon.astro";
+
 import Globe from "@/assets/icons/mask/globe.avif?url";
 
 const currentLocale = getLocale(Astro.url);

--- a/src/components/ui/header/NavItem.astro
+++ b/src/components/ui/header/NavItem.astro
@@ -1,9 +1,11 @@
 ---
-import dropdownCaret from "@/assets/icons/mask/dropdown-caret.avif?url";
-import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
-import MaskIcon from "@/components/ui/MaskIcon.astro";
-import ColorIcon from "@/components/ui/ColorIcon.astro";
 import { getDirection, getLocale } from "@/i18n/utils";
+
+import ColorIcon from "@/components/ui/ColorIcon.astro";
+import MaskIcon from "@/components/ui/MaskIcon.astro";
+
+import arrowRight from "@/assets/icons/mask/arrow-right.avif?url";
+import dropdownCaret from "@/assets/icons/mask/dropdown-caret.avif?url";
 
 export interface DropdownItem {
   label: string;

--- a/src/components/ui/header/NavItem.astro
+++ b/src/components/ui/header/NavItem.astro
@@ -129,7 +129,6 @@ const dir = getDirection(getLocale(Astro.url));
     position: relative;
     display: flex;
     align-items: center;
-    gap: 0.35rem;
     padding: 0.4rem 0;
   }
 
@@ -137,7 +136,6 @@ const dir = getDirection(getLocale(Astro.url));
     color: var(--paragraph-main);
     text-decoration: none;
     font-weight: 500;
-    flex: 1;
     display: flex;
     align-items: center;
     user-select: none;
@@ -260,8 +258,19 @@ const dir = getDirection(getLocale(Astro.url));
     opacity: 1;
   }
 
+  /* highlight link when hovered/focused */
+  .nav-item--dropdown:is(
+      :hover,
+      :focus-within,
+      :has(.dropdown :focus-visible)
+    )
+    > .row
+    > .link {
+    color: var(--heading-color);
+  }
+
   /* === Desktop hover/focus behaviour === */
-  @media (hover: hover) and (pointer: fine) {
+  @media (hover: hover) and (pointer: fine) and (min-width: 1201px) {
     /* show dropdown on hover/focus */
     .nav-item--dropdown:is(
         :hover,
@@ -272,17 +281,6 @@ const dir = getDirection(getLocale(Astro.url));
       visibility: visible;
       pointer-events: auto;
       transform: translateY(0);
-    }
-
-    /* highlight link when open */
-    .nav-item--dropdown:is(
-        :hover,
-        :focus-within,
-        :has(.dropdown :focus-visible)
-      )
-      > .row
-      > .link {
-      color: var(--heading-color);
     }
 
     /* rotate caret when open */
@@ -307,10 +305,6 @@ const dir = getDirection(getLocale(Astro.url));
 
   /* === Mobile / tablet (drawer accordion) === */
   @media (max-width: 1200px) {
-    .item {
-      position: relative;
-    }
-
     .row {
       padding: 0.5rem 0;
     }
@@ -328,19 +322,6 @@ const dir = getDirection(getLocale(Astro.url));
       display: none;
     }
 
-    .dd-toggle:checked ~ .row .mobile-open {
-      display: none;
-    }
-
-    .dd-toggle:checked ~ .row .mobile-close {
-      display: block;
-      position: absolute;
-      inset: 0;
-      pointer-events: auto;
-      cursor: pointer;
-      z-index: 1;
-    }
-
     .dropdown {
       position: static;
       width: unset;
@@ -351,7 +332,6 @@ const dir = getDirection(getLocale(Astro.url));
       /* accordion behaviour - collapsed by default */
       max-height: 0;
       overflow: hidden;
-      transform: unset;
     }
 
     .dropdown::before {
@@ -362,7 +342,7 @@ const dir = getDirection(getLocale(Astro.url));
       background: none;
       box-shadow: none;
       border-radius: 0;
-      padding-block: 0.5rem 0.5rem;
+      padding-block: 1rem 0rem;
     }
 
     .dropdown-content {
@@ -375,8 +355,21 @@ const dir = getDirection(getLocale(Astro.url));
       max-height: unset;
     }
 
-    .dd-toggle:checked ~ .row > .caret {
+    .dd-toggle:checked ~ .row > .link > .caret {
       transform: rotate(180deg);
+    }
+
+    .dd-toggle:checked ~ .row .mobile-open {
+      display: none;
+    }
+
+    .dd-toggle:checked ~ .row .mobile-close {
+      display: block;
+      position: absolute;
+      inset: 0;
+      pointer-events: auto;
+      cursor: pointer;
+      z-index: 1;
     }
   }
 

--- a/src/components/ui/header/NavItem.astro
+++ b/src/components/ui/header/NavItem.astro
@@ -259,11 +259,7 @@ const dir = getDirection(getLocale(Astro.url));
   }
 
   /* highlight link when hovered/focused */
-  .nav-item--dropdown:is(
-      :hover,
-      :focus-within,
-      :has(.dropdown :focus-visible)
-    )
+  .nav-item--dropdown:is(:hover, :focus-within, :has(.dropdown :focus-visible))
     > .row
     > .link {
     color: var(--heading-color);

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -5,5 +5,4 @@ export const locales = {
   fr: "fr-FR",
   ar: "ar-SA",
 };
-
 export const rtlLocales = ["ar", "he", "fa", "ur"]; // Arabic, Hebrew, Persian, Urdu

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,7 +1,8 @@
-import { defaultLocale, locales, rtlLocales } from "@/i18n/config";
 import { getLocale } from "astro-i18n-aut";
 import { createInstance } from "i18next";
 import Backend from "i18next-fs-backend";
+
+import { defaultLocale, locales, rtlLocales } from "@/i18n/config";
 
 export const localizeHref = (locale: string, href: string): string => {
   if (href.startsWith("http")) return href;
@@ -11,33 +12,29 @@ export const localizeHref = (locale: string, href: string): string => {
   return `${localized}/`;
 };
 
-export const getLocaleName = (locale: string): { name: string } | null => {
-  const fullLocale = (locales as Record<string, string>)[locale];
-  if (!fullLocale) return null;
-  const displayNames = new Intl.DisplayNames([locale], { type: "language" });
-  const name = displayNames.of(locale);
-  if (!name) return null;
-  const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
-  return { name: capitalizedName };
-};
-
-export const getDirection = (locale: string): "ltr" | "rtl" => {
-  return rtlLocales.includes(locale) ? "rtl" : "ltr";
-};
-
 export const localizeNumber = (
   number: number,
   locale: string,
   minimumIntegerDigits: number = 1,
 ): string => {
-  if (!Object.keys(locales).includes(locale)) {
-    locale = defaultLocale;
-  }
-  const localeString = locales[locale as keyof typeof locales];
+  // We map the short locale (ex. "ar") to the full locale string ("ar-SA") from config.ts
+  const localeString =
+    (locales as Record<string, string>)[locale] || locales[defaultLocale];
   return number.toLocaleString(localeString, {
-    minimumIntegerDigits: minimumIntegerDigits,
+    minimumIntegerDigits,
     useGrouping: false,
   });
+};
+
+export const getLocaleName = (locale: string): { name: string } | null => {
+  const displayNames = new Intl.DisplayNames([locale], { type: "language" });
+  const name = displayNames.of(locale);
+  if (!name) return null;
+  return { name: name.charAt(0).toUpperCase() + name.slice(1) };
+};
+
+export const getDirection = (locale: string): "ltr" | "rtl" => {
+  return rtlLocales.includes(locale) ? "rtl" : "ltr";
 };
 
 export const createTInstance = (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,12 +1,12 @@
 ---
-import Header from "@/components/layout/Header.astro";
 import Footer from "@/components/layout/Footer.astro";
-import "@fontsource-variable/dm-sans";
-import "@fontsource-variable/inter";
-import dmSansFont from "@fontsource-variable/dm-sans/files/dm-sans-latin-wght-normal.woff2?url";
-import "@/styles/global.css";
-import { getLocale } from "astro-i18n-aut";
+import Header from "@/components/layout/Header.astro";
 import { createTInstance, getDirection } from "@/i18n/utils";
+import "@/styles/global.css";
+import "@fontsource-variable/dm-sans";
+import dmSansFont from "@fontsource-variable/dm-sans/files/dm-sans-latin-wght-normal.woff2?url";
+import "@fontsource-variable/inter";
+import { getLocale } from "astro-i18n-aut";
 
 const lang = getLocale(Astro.url);
 const t = await createTInstance(lang);

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/community/hangouts.astro
+++ b/src/pages/community/hangouts.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/community/sponsorships.astro
+++ b/src/pages/community/sponsorships.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/community/workgroups.astro
+++ b/src/pages/community/workgroups.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -9,8 +9,6 @@ import CoreCard from "@/components/pages/downloads/CoreCard.astro";
 import Tabs from "@/components/ui/Tabs.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 
-
-
 import communityWallets from "@/data/downloads/community.json";
 import coreDownloads from "@/data/downloads/core.json";
 

--- a/src/pages/downloads.astro
+++ b/src/pages/downloads.astro
@@ -1,13 +1,18 @@
 ---
-import Layout from "@/layouts/Layout.astro";
-import TitleCard from "@/components/ui/TitleCard.astro";
-import Tabs from "@/components/ui/Tabs.astro";
-import CommunityCard from "@/components/pages/downloads/CommunityCard.astro";
-import CoreCard from "@/components/pages/downloads/CoreCard.astro";
 import { createTInstance, getLocale } from "@/i18n/utils";
-import coreDownloads from "@/data/downloads/core.json";
-import communityWallets from "@/data/downloads/community.json";
+
+import Layout from "@/layouts/Layout.astro";
+
+import CommunityCard from "@/components/pages/downloads/CommunityCard.astro";
 import type { DownloadLink } from "@/components/pages/downloads/CoreCard.astro";
+import CoreCard from "@/components/pages/downloads/CoreCard.astro";
+import Tabs from "@/components/ui/Tabs.astro";
+import TitleCard from "@/components/ui/TitleCard.astro";
+
+
+
+import communityWallets from "@/data/downloads/community.json";
+import coreDownloads from "@/data/downloads/core.json";
 
 const locale = getLocale(Astro.url);
 const t = await createTInstance(locale, "downloads");

--- a/src/pages/get-started/accept-monero.astro
+++ b/src/pages/get-started/accept-monero.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/get-started/contribute.astro
+++ b/src/pages/get-started/contribute.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/get-started/exchanges.astro
+++ b/src/pages/get-started/exchanges.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/get-started/faq.astro
+++ b/src/pages/get-started/faq.astro
@@ -1,10 +1,6 @@
 ---
-import Layout from "@/layouts/Layout.astro";
-import TitleCard from "@/components/ui/TitleCard.astro";
-import Accordion from "@/components/ui/Accordion.astro";
-import type { AccordionItem } from "@/components/ui/Accordion.astro";
-import IndexCard from "@/components/pages/index/IndexCard.astro";
-import ResourceCard from "@/components/pages/index/ResourceCard.astro";
+import "@/styles/moneropedia-link.css";
+
 import { createTInstance, getLocale } from "@/i18n/utils";
 import {
   getMoneropediaEntries,
@@ -12,11 +8,17 @@ import {
 } from "@/utils/moneropedia";
 import { marked } from "marked";
 
-import userGuidesIcon from "@/assets/icons/mask/user-guides.avif?url";
+import Layout from "@/layouts/Layout.astro";
+
+import IndexCard from "@/components/pages/index/IndexCard.astro";
+import ResourceCard from "@/components/pages/index/ResourceCard.astro";
+import type { AccordionItem } from "@/components/ui/Accordion.astro";
+import Accordion from "@/components/ui/Accordion.astro";
+import TitleCard from "@/components/ui/TitleCard.astro";
+
 import developerGuidesIcon from "@/assets/icons/mask/developer-guides.avif?url";
 import faqIcon from "@/assets/icons/mask/faq.avif?url";
-
-import "@/styles/moneropedia-link.css";
+import userGuidesIcon from "@/assets/icons/mask/user-guides.avif?url";
 
 const locale = getLocale(Astro.url);
 const t = await createTInstance(locale);

--- a/src/pages/get-started/merchants.astro
+++ b/src/pages/get-started/merchants.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/get-started/mining.astro
+++ b/src/pages/get-started/mining.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/get-started/what-is-monero.astro
+++ b/src/pages/get-started/what-is-monero.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,18 @@
 ---
+import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
+
 import Layout from "@/layouts/Layout.astro";
+
+import GetStartedCard from "@/components/pages/index/GetStartedCard.astro";
 import Hero from "@/components/pages/index/Hero.astro";
 import IndexCard from "@/components/pages/index/IndexCard.astro";
-import GetStartedCard from "@/components/pages/index/GetStartedCard.astro";
 import ResourceCard from "@/components/pages/index/ResourceCard.astro";
-import placeholder from "@/assets/icons/mask/placeholder.avif?url";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 
-import userGuidesIcon from "@/assets/icons/mask/user-guides.avif?url";
-import faqIcon from "@/assets/icons/mask/faq.avif?url";
 import developerGuidesIcon from "@/assets/icons/mask/developer-guides.avif?url";
+import faqIcon from "@/assets/icons/mask/faq.avif?url";
+import placeholder from "@/assets/icons/mask/placeholder.avif?url";
+import userGuidesIcon from "@/assets/icons/mask/user-guides.avif?url";
 
 const locale = getLocale(Astro.url);
 const t = await createTInstance(locale);

--- a/src/pages/legal.astro
+++ b/src/pages/legal.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/developer-guides.astro
+++ b/src/pages/resources/developer-guides.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/knowledge-base.astro
+++ b/src/pages/resources/knowledge-base.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/monero-tools.astro
+++ b/src/pages/resources/monero-tools.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/moneropedia/[...slug].astro
+++ b/src/pages/resources/moneropedia/[...slug].astro
@@ -1,16 +1,19 @@
 ---
-import type { CollectionEntry } from "astro:content";
-import { getCollection, getEntry } from "astro:content";
-import Layout from "@/layouts/Layout.astro";
-import MoneropediaContent from "@/components/pages/moneropedia/MoneropediaContent.astro";
 import { defaultLocale } from "@/i18n/config";
 import {
-  localizeHref,
-  getLocale,
   createTInstance,
   getDirection,
+  getLocale,
+  localizeHref,
 } from "@/i18n/utils";
+import type { CollectionEntry } from "astro:content";
+import { getCollection, getEntry } from "astro:content";
+
+import Layout from "@/layouts/Layout.astro";
+
+import MoneropediaContent from "@/components/pages/moneropedia/MoneropediaContent.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
+
 import backCaret from "@/assets/icons/mask/back-caret.avif?url";
 
 export async function getStaticPaths() {

--- a/src/pages/resources/moneropedia/index.astro
+++ b/src/pages/resources/moneropedia/index.astro
@@ -9,7 +9,6 @@ import Layout from "@/layouts/Layout.astro";
 import Accordion from "@/components/ui/Accordion.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 
-
 type MoneropediaItem = CollectionEntry<"moneropedia"> & {
   href: string;
   title: string;

--- a/src/pages/resources/moneropedia/index.astro
+++ b/src/pages/resources/moneropedia/index.astro
@@ -1,11 +1,14 @@
 ---
+import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
+import safeMarkdown from "@/utils/safeMarkdown";
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
-import Accordion from "@/components/ui/Accordion.astro";
+
 import Layout from "@/layouts/Layout.astro";
-import { getLocale, createTInstance, localizeHref } from "@/i18n/utils";
+
+import Accordion from "@/components/ui/Accordion.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import safeMarkdown from "@/utils/safeMarkdown";
+
 
 type MoneropediaItem = CollectionEntry<"moneropedia"> & {
   href: string;

--- a/src/pages/resources/press-kit.astro
+++ b/src/pages/resources/press-kit.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/research-lab.astro
+++ b/src/pages/resources/research-lab.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/roadmap.astro
+++ b/src/pages/resources/roadmap.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/pages/resources/user-guides.astro
+++ b/src/pages/resources/user-guides.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from "@/layouts/Layout.astro";
+
 import TitleCard from "@/components/ui/TitleCard.astro";
 ---
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,8 +71,9 @@
 }
 
 /* ========================================
-   Global HTML Element Styles
+   Global HTML Element Styles (do not define classes here!)
    ======================================== */
+
 a {
   color: var(--monero-orange);
   text-decoration: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -23,6 +23,7 @@
 
   /* Typography - Font Sizes */
   --font-size-base: 1rem; /* body-base */
+  --font-size-xs: 0.75rem; /* extra small text */
   --font-size-sm: 0.9rem; /* small text */
   --font-size-lg: 1.125rem; /* body-lg */
   --font-size-xl: clamp(1.2rem, 2vw, 1.5rem); /* subhead1 */

--- a/src/utils/moneropedia.ts
+++ b/src/utils/moneropedia.ts
@@ -1,4 +1,5 @@
 import { getCollection } from "astro:content";
+
 import { defaultLocale } from "@/i18n/config";
 
 export interface MoneropediaEntry {

--- a/src/utils/safeMarkdown.ts
+++ b/src/utils/safeMarkdown.ts
@@ -1,5 +1,5 @@
-import { marked } from "marked";
 import DOMPurify from "isomorphic-dompurify";
+import { marked } from "marked";
 
 export const parse = (markdown: string): string => {
   return DOMPurify.sanitize(marked.parse(markdown) as string);


### PR DESCRIPTION
Reorganizes import statements across files to improve consistency and maintainability.
Adds the `prettier-plugin-astro-organize-imports` plugin to automate this process.
Minor code cleanups