### PR TITLE
patch: use process.cwd to determine moneropedia root

### DIFF
--- a/src/pages/blog/[...post].astro
+++ b/src/pages/blog/[...post].astro
@@ -7,11 +7,11 @@ import {
   localizeDateString,
   localizeHref,
 } from "@/i18n/utils";
+import Layout from "@/layouts/Layout.astro";
 import { getDateStringFromId } from "@/utils/blog";
 import type { GetStaticPaths } from "astro";
 import type { CollectionEntry } from "astro:content";
 import { getCollection, render } from "astro:content";
-import Layout from "../../layouts/Layout.astro";
 
 export const getStaticPaths: GetStaticPaths = async () => {
   const posts = await getCollection("blog");

--- a/src/utils/moneropedia.ts
+++ b/src/utils/moneropedia.ts
@@ -1,6 +1,5 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import fg from "fast-glob";
 import matter from "gray-matter";
@@ -10,8 +9,11 @@ import escapeStringRegexp from "escape-string-regexp";
 
 export const MONEROPEDIA_SUFFIXES = ["based", "like", "form"] as const;
 export const MONEROPEDIA_LOOKAHEAD = `(${MONEROPEDIA_SUFFIXES.join("|")})`;
-const MONEROPEDIA_ROOT = fileURLToPath(
-  new URL("../content/moneropedia", import.meta.url),
+const MONEROPEDIA_ROOT = path.resolve(
+  process.cwd(),
+  "src",
+  "content",
+  "moneropedia",
 );
 
 export interface MoneropediaEntry {


### PR DESCRIPTION
Changes the way the `MONEROPEDIA_ROOT` is defined to use `process.cwd()` to make path resolution not break under different build contexts (Astro/Vite vs Node)