### PR TITLE
move localization functions to global context

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,7 @@ import tseslint from "typescript-eslint";
 export default defineConfig([
   {
     name: "ignores",
-    ignores: ["dist/**", ".astro/**", ".husky/**", "node_modules/**"],
+    ignores: ["dist/**", ".astro/**", "node_modules/**"],
   },
 
   js.configs.recommended,

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,16 +1,12 @@
 ---
-import { getDirection, localizeHref } from "@/i18n/utils";
 import { isExternal } from "@/utils/links";
 import type { ImageMetadata } from "astro";
-import { getLocale } from "astro-i18n-aut";
 
 import rssIcon from "@/assets/icons/mask/rss.avif";
 import torIcon from "@/assets/icons/mask/tor.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 
-const { t } = Astro.props;
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
+const { t, dir, localizeHref } = Astro.locals;
 
 interface Link {
   label: string;
@@ -34,11 +30,11 @@ const columns: Column[] = [
     links: [
       {
         label: t("common:footer.columns.resources.links.aboutMonero"),
-        href: localizeHref(locale, "/get-started/what-is-monero/"),
+        href: localizeHref("/get-started/what-is-monero/"),
       },
       {
         label: t("common:footer.columns.resources.links.moneropedia"),
-        href: localizeHref(locale, "/resources/moneropedia/"),
+        href: localizeHref("/resources/moneropedia/"),
       },
       {
         label: t("common:footer.columns.resources.links.moneroDocs"),
@@ -46,7 +42,7 @@ const columns: Column[] = [
       },
       {
         label: t("common:footer.columns.resources.links.faq"),
-        href: localizeHref(locale, "/get-started/faq"),
+        href: localizeHref("/get-started/faq"),
       },
     ],
   },
@@ -55,11 +51,11 @@ const columns: Column[] = [
     links: [
       {
         label: t("common:footer.columns.reachOut.links.workgroups"),
-        href: localizeHref(locale, "/community/workgroups"),
+        href: localizeHref("/community/workgroups"),
       },
       {
         label: t("common:footer.columns.reachOut.links.hangouts"),
-        href: localizeHref(locale, "/community/hangouts"),
+        href: localizeHref("/community/hangouts"),
       },
       {
         label: t("common:footer.columns.reachOut.links.mailingList"),
@@ -95,11 +91,11 @@ const columns: Column[] = [
         label: t(
           "common:footer.columns.theMoneroProject.links.moneroResearchLab",
         ),
-        href: localizeHref(locale, "/resources/research-lab"),
+        href: localizeHref("/resources/research-lab"),
       },
       {
         label: t("common:footer.columns.theMoneroProject.links.pressKit"),
-        href: localizeHref(locale, "/resources/press-kit"),
+        href: localizeHref("/resources/press-kit"),
       },
       {
         label: t(
@@ -128,7 +124,7 @@ const bottomLinks: Link[] = [
   },
   {
     label: t("common:footer.bottomLinks.legal"),
-    href: localizeHref(locale, "/legal"),
+    href: localizeHref("/legal"),
   },
   {
     label: t("common:footer.bottomLinks.sourceCode"),

--- a/src/components/layout/header/Header.astro
+++ b/src/components/layout/header/Header.astro
@@ -1,6 +1,4 @@
 ---
-import { localizeHref } from "@/i18n/utils";
-import { getLocale } from "astro-i18n-aut";
 import { Image } from "astro:assets";
 
 import LanguageDropdown from "@/components/layout/header/LanguageDropdown.astro";
@@ -13,8 +11,7 @@ import moneroLogo from "@/../public/meta/monerologo.avif";
 import close from "@/assets/icons/mask/close.avif";
 import hamburger from "@/assets/icons/mask/hamburger.avif";
 
-const { t } = Astro.props;
-const locale = getLocale(Astro.url);
+const { t, localizeHref } = Astro.locals;
 
 const navItems = navigationItems.map((item) => {
   const label = t(`common:header.nav.${item.translationKey}`);
@@ -25,7 +22,7 @@ const navItems = navigationItems.map((item) => {
       dropdown: item.items.map(({ key, href, icon, iconDark }) => ({
         label: t(`common:header.dropdowns.${item.section}.${key}.label`),
         desc: t(`common:header.dropdowns.${item.section}.${key}.desc`),
-        href: localizeHref(locale, href),
+        href: localizeHref(href),
         icon,
         iconDark,
       })),
@@ -34,14 +31,14 @@ const navItems = navigationItems.map((item) => {
 
   return {
     label,
-    href: localizeHref(locale, item.href),
+    href: localizeHref(item.href),
   };
 });
 ---
 
 <header class="header">
   <div class="header-inner">
-    <a class="brand" href={localizeHref(locale, "/")}>
+    <a class="brand" href={localizeHref("/")}>
       <Image
         class="mark"
         src={moneroLogo}
@@ -84,7 +81,7 @@ const navItems = navigationItems.map((item) => {
 
     <div class="utils" aria-label={t("common:aria.utilities")}>
       <div class="lang">
-        <LanguageDropdown t={t} />
+        <LanguageDropdown />
       </div>
       <label
         for="nav-toggle"

--- a/src/components/layout/header/LanguageDropdown.astro
+++ b/src/components/layout/header/LanguageDropdown.astro
@@ -1,19 +1,12 @@
 ---
 import { locales } from "@/i18n/config";
 import { getLocaleName, localizeHref } from "@/i18n/utils";
-import { getLocale } from "astro-i18n-aut";
-import type { TFunction } from "i18next";
 
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 
 import Globe from "@/assets/icons/mask/globe.avif";
 
-interface Props {
-  t: TFunction;
-}
-
-const { t } = Astro.props;
-const currentLocale = getLocale(Astro.url);
+const { t, locale: currentLocale } = Astro.locals;
 
 const localeList = Object.keys(locales).map((code) => {
   const { name = code } = getLocaleName(code) ?? {};

--- a/src/components/layout/header/NavItem.astro
+++ b/src/components/layout/header/NavItem.astro
@@ -1,5 +1,4 @@
 ---
-import { getDirection, getLocale } from "@/i18n/utils";
 import type { ImageMetadata } from "astro";
 
 import ColorIcon from "@/components/ui/ColorIcon.astro";
@@ -26,7 +25,7 @@ const { label, href, dropdown = [] } = Astro.props;
 const isDropdown = dropdown.length > 0;
 const id = "dd-" + Math.random().toString(36).slice(2, 11);
 const closeId = id + "-close";
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const rtl = Astro.locals.dir === "rtl";
 ---
 
 <li class:list={["nav-item", { "nav-item--dropdown": isDropdown }]}>

--- a/src/components/pages/accept-monero/GuideStep.astro
+++ b/src/components/pages/accept-monero/GuideStep.astro
@@ -2,7 +2,6 @@
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 
 export interface Props {
   step: number | string;
@@ -11,7 +10,6 @@ export interface Props {
   image?: ImageMetadata;
   imageAlt?: string;
   reverse?: boolean;
-  t: TFunction;
 }
 
 const {
@@ -21,8 +19,8 @@ const {
   image,
   imageAlt = "",
   reverse = false,
-  t,
 } = Astro.props;
+const { t } = Astro.locals;
 ---
 
 <section class:list={["guide-step", { reverse }]}>

--- a/src/components/pages/blog/BlogCard.astro
+++ b/src/components/pages/blog/BlogCard.astro
@@ -2,11 +2,9 @@
 import calendarIcon from "@/assets/icons/mask/calendar.avif";
 import userIcon from "@/assets/icons/mask/user.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { localizeDateString, localizeHref } from "@/i18n/utils";
 import { getDateStringFromId } from "@/utils/blog.ts";
 import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 
 interface Props {
   id: string;
@@ -15,18 +13,17 @@ interface Props {
   title: string;
   summary: string;
   image?: ImageMetadata;
-  locale: string;
-  t: TFunction;
 }
 
-const { author, tags, title, summary, image, id, locale, t } = Astro.props;
+const { author, tags, title, summary, image, id } = Astro.props;
+const { t, localizeHref, localizeDateString } = Astro.locals;
 const dateString = getDateStringFromId(id);
-const date = localizeDateString(dateString, locale, {
+const date = localizeDateString(dateString, {
   day: "numeric",
   month: "long",
   year: "numeric",
 });
-const localizedLink = localizeHref(locale, `/blog/${id}/`);
+const localizedLink = localizeHref(`/blog/${id}/`);
 ---
 
 <div class="card-container">
@@ -85,7 +82,6 @@ const localizedLink = localizeHref(locale, `/blog/${id}/`);
             <a
               class="tag"
               href={localizeHref(
-                locale,
                 `/blog/tags/${tag.toLowerCase().replace(/\s+/g, "-")}/`,
               )}
             >

--- a/src/components/pages/blog/BlogHeader.astro
+++ b/src/components/pages/blog/BlogHeader.astro
@@ -1,26 +1,22 @@
 ---
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { localizeHref } from "@/i18n/utils";
-import type { TFunction } from "i18next";
+import { getDateStringFromId } from "@/utils/blog.ts";
 
 import calendarIcon from "@/assets/icons/mask/calendar.avif";
 import userIcon from "@/assets/icons/mask/user.avif";
-import { localizeDateString } from "@/i18n/utils";
-import { getDateStringFromId } from "@/utils/blog.ts";
 
 interface Props {
   title: string;
   id: string;
   author: string;
   tags?: string[];
-  locale: string;
-  t: TFunction;
 }
 
-const { title, id, author, tags = [], locale, t } = Astro.props;
+const { title, id, author, tags = [] } = Astro.props;
+const { t, localizeHref, localizeDateString } = Astro.locals;
 
 const dateString = getDateStringFromId(id);
-const date = localizeDateString(dateString, locale, {
+const date = localizeDateString(dateString, {
   day: "numeric",
   month: "long",
   year: "numeric",
@@ -61,7 +57,6 @@ const date = localizeDateString(dateString, locale, {
           <a
             class="tag"
             href={localizeHref(
-              locale,
               `/blog/tags/${tag.toLowerCase().replace(/\s+/g, "-")}/`,
             )}
           >

--- a/src/components/pages/downloads/CommunityCard.astro
+++ b/src/components/pages/downloads/CommunityCard.astro
@@ -9,7 +9,6 @@ import androidIcon from "@/assets/icons/mask/brand/android.avif";
 import appleIcon from "@/assets/icons/mask/brand/apple.avif";
 import linuxIcon from "@/assets/icons/mask/brand/linux.avif";
 import windowsIcon from "@/assets/icons/mask/brand/windows.avif";
-import type { TFunction } from "i18next";
 
 interface Tags {
   desktop?: string[]; // windows | macos | linux (aliases: win, mac, osx)
@@ -25,7 +24,6 @@ interface Props {
   link: string;
   linkText?: string;
   translateTag?: (key: string) => string;
-  t: TFunction;
   id?: string;
 }
 
@@ -37,9 +35,9 @@ const {
   link,
   linkText,
   translateTag,
-  t,
   id,
 } = Astro.props;
+const { t } = Astro.locals;
 
 const norm = (s: string) => (s || "").toLowerCase().trim();
 const ALIAS: Record<string, string> = {

--- a/src/components/pages/downloads/CoreCard.astro
+++ b/src/components/pages/downloads/CoreCard.astro
@@ -1,8 +1,6 @@
 ---
-import { createSafeMarkdown } from "@/utils/safeMarkdown.ts";
 import type { ImageMetadata } from "astro";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 
 import Button from "@/components/ui/Button.astro";
 import ColorIcon from "@/components/ui/ColorIcon.astro";
@@ -40,7 +38,6 @@ interface Props {
   releaseNotesUrl?: string;
   torrentUrl?: string;
   magnetUrl?: string;
-  t: TFunction;
 }
 
 const {
@@ -56,9 +53,9 @@ const {
   releaseNotesUrl,
   torrentUrl,
   magnetUrl,
-  t,
   ...rest
 } = Astro.props;
+const { t, safeMarkdown } = Astro.locals;
 
 const PLATFORM_ICONS: Record<string, ImageMetadata> = {
   windows: windowsIcon,
@@ -67,8 +64,6 @@ const PLATFORM_ICONS: Record<string, ImageMetadata> = {
   android: androidIcon,
   freebsd: freebsdIcon,
 };
-
-const safeMarkdown = createSafeMarkdown();
 ---
 
 <div class="download-card" id={id} {...rest}>

--- a/src/components/pages/get-started/exchanges/ExchangeTable.astro
+++ b/src/components/pages/get-started/exchanges/ExchangeTable.astro
@@ -1,7 +1,6 @@
 ---
 import { getPublicImageDimensions } from "@/utils/image";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 
 export interface Props {
   exchanges: Array<{
@@ -18,10 +17,10 @@ export interface Props {
     userFriendly?: boolean;
   }>;
   hasKyc: boolean;
-  t: TFunction;
 }
 
-const { exchanges, hasKyc, t } = Astro.props;
+const { exchanges, hasKyc } = Astro.props;
+const { t } = Astro.locals;
 
 if (!exchanges) {
   throw new Error("ExchangeTable component requires 'exchanges' prop.");

--- a/src/components/pages/hangouts/IRCChannelButton.astro
+++ b/src/components/pages/hangouts/IRCChannelButton.astro
@@ -2,19 +2,17 @@
 import externalLinkIcon from "@/assets/icons/mask/external-link.avif";
 import matrixIcon from "@/assets/icons/mask/matrix.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getDirection, getLocale } from "@/i18n/utils";
-import type { TFunction } from "i18next";
 
 export interface Props {
   name: string;
   description: string;
   href: string;
   matrixHref?: string;
-  t: TFunction;
 }
 
-const { name, description, href, matrixHref, t } = Astro.props;
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const { name, description, href, matrixHref } = Astro.props;
+const { t, dir } = Astro.locals;
+const rtl = dir === "rtl";
 
 // Split channel name into prefix (muted) and suffix (highlighted)
 const parseChannelName = (channelName: string) => {

--- a/src/components/pages/index/GetStartedCard.astro
+++ b/src/components/pages/index/GetStartedCard.astro
@@ -1,7 +1,4 @@
 ---
-import { getDirection, localizeHref, localizeNumber } from "@/i18n/utils";
-import { getLocale } from "astro-i18n-aut";
-
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 
 import arrowRight from "@/assets/icons/mask/arrow-right.avif";
@@ -16,19 +13,18 @@ export interface Props {
 
 const { step, title, description = "", ctaHref = "#", ctaLabel } = Astro.props;
 
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
+const { dir, localizeNumber, localizeHref } = Astro.locals;
 ---
 
 <article class="gs">
   <div class="num" aria-hidden="true">
-    {localizeNumber(locale, Number(step), 2)}
+    {localizeNumber(Number(step), 2)}
   </div>
 
   <div class="text">
     <h2 class="title">{title}</h2>
     {description && <p class="desc">{description}</p>}
-    <a class="cta" href={localizeHref(locale, ctaHref)} target="_blank">
+    <a class="cta" href={localizeHref(ctaHref)} target="_blank">
       {ctaLabel}
       <MaskIcon src={arrowRight} rtl={dir == "rtl"} size="1em" />
     </a>

--- a/src/components/pages/index/Hero.astro
+++ b/src/components/pages/index/Hero.astro
@@ -1,13 +1,11 @@
 ---
-import { getLocale, localizeHref } from "@/i18n/utils";
-
 import Button from "@/components/ui/Button.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 
 import moneroOutline from "@/assets/icons/mask/monerooutline.avif";
 
-const { t, class: className, ...rest } = Astro.props;
-const locale = getLocale(Astro.url);
+const { class: className, ...rest } = Astro.props;
+const { t, localizeHref } = Astro.locals;
 ---
 
 <div class:list={["hero", className]} aria-labelledby="hero-title" {...rest}>
@@ -38,7 +36,7 @@ const locale = getLocale(Astro.url);
       <Button
         variant="secondary"
         class="hero-button"
-        href={localizeHref(locale, "/get-started/what-is-monero/")}
+        href={localizeHref("/get-started/what-is-monero/")}
         >{t("index:hero.aboutMonero")}</Button
       >
     </div>

--- a/src/components/pages/index/ResourceCard.astro
+++ b/src/components/pages/index/ResourceCard.astro
@@ -1,6 +1,4 @@
 ---
-import { getDirection, getLocale } from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
 import type { ImageMetadata } from "astro";
 
 import MaskIcon from "@/components/ui/MaskIcon.astro";
@@ -17,8 +15,8 @@ export interface Props {
 }
 
 const { icon = null, title, description = "", ctaLabel, ctaHref } = Astro.props;
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
-const safeMarkdown = createSafeMarkdown(getLocale(Astro.url));
+const { dir, safeMarkdown } = Astro.locals;
+const rtl = dir === "rtl";
 ---
 
 <article class="resource-card">

--- a/src/components/pages/resources/library/BookCard.astro
+++ b/src/components/pages/resources/library/BookCard.astro
@@ -3,18 +3,14 @@ import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import bookTextIcon from "@/assets/icons/mask/bookText.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 import type { Book } from "@/data/library";
-import { getDirection, getLocale } from "@/i18n/utils";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 
-export interface Props extends Book {
-  t: TFunction;
-}
+export type Props = Book;
 
-const { title, subtitle, description, cover, coverAlt, link, translations, t } =
+const { title, subtitle, description, cover, coverAlt, link, translations } =
   Astro.props;
-const locale = getLocale(Astro.url);
-const rtl = getDirection(locale) === "rtl";
+const { t, dir } = Astro.locals;
+const rtl = dir === "rtl";
 
 const getLanguageName = (targetLocale: string): string => {
   const displayNames = new Intl.DisplayNames([targetLocale], {

--- a/src/components/pages/resources/research-lab/PaperCard.astro
+++ b/src/components/pages/resources/research-lab/PaperCard.astro
@@ -1,8 +1,6 @@
 ---
 import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getDirection, getLocale } from "@/i18n/utils";
-import type { TFunction } from "i18next";
 
 interface Props {
   code?: string;
@@ -10,11 +8,11 @@ interface Props {
   abstract: string;
   url: string;
   note?: string;
-  t: TFunction;
 }
 
-const { code, title, abstract, url, note, t } = Astro.props;
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const { code, title, abstract, url, note } = Astro.props;
+const { t, dir } = Astro.locals;
+const rtl = dir === "rtl";
 ---
 
 <article class="paper-card">

--- a/src/components/pages/roadmap/HistoryTimeline.astro
+++ b/src/components/pages/roadmap/HistoryTimeline.astro
@@ -1,6 +1,4 @@
 ---
-import type { TFunction } from "i18next";
-
 interface HistoryEvent {
   month?: string;
   titleKey: string;
@@ -14,10 +12,10 @@ interface HistoryYear {
 
 interface Props {
   history: HistoryYear[];
-  t: TFunction;
 }
 
-const { history, t } = Astro.props;
+const { history } = Astro.props;
+const { t } = Astro.locals;
 ---
 
 <div class="year-rows">

--- a/src/components/pages/roadmap/StatusSection.astro
+++ b/src/components/pages/roadmap/StatusSection.astro
@@ -1,8 +1,6 @@
 ---
 import externalLinkIcon from "@/assets/icons/mask/external-link.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getDirection, getLocale } from "@/i18n/utils";
-import type { TFunction } from "i18next";
 
 interface Props {
   items: Array<{
@@ -11,12 +9,12 @@ interface Props {
     status: string;
   }>;
   status: "in-progress" | "upcoming" | "proposed";
-  t: TFunction;
 }
 
-const { items, status, t } = Astro.props;
+const { items, status } = Astro.props;
+const { t, dir } = Astro.locals;
 const filteredItems = items.filter((item) => item.status === status);
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const rtl = dir === "rtl";
 ---
 
 <ul class="status-list">

--- a/src/components/pages/workgroups/WorkgroupCard.astro
+++ b/src/components/pages/workgroups/WorkgroupCard.astro
@@ -1,7 +1,6 @@
 ---
 import MaskIcon from "@/components/ui/MaskIcon.astro";
 import type { ImageMetadata } from "astro";
-import type { TFunction } from "i18next";
 
 import matrixIcon from "@/assets/icons/mask/matrix.avif";
 
@@ -13,11 +12,11 @@ export interface Props {
   chatName: string;
   ircHref: string;
   matrixHref?: string;
-  t: TFunction;
 }
 
-const { name, action, bestFor, icon, chatName, ircHref, matrixHref, t } =
+const { name, action, bestFor, icon, chatName, ircHref, matrixHref } =
   Astro.props;
+const { t } = Astro.locals;
 ---
 
 <article class="workgroup-card">

--- a/src/components/ui/CategoryCard.astro
+++ b/src/components/ui/CategoryCard.astro
@@ -1,7 +1,6 @@
 ---
 import arrowRight from "@/assets/icons/mask/arrow-right.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getDirection, getLocale, createTInstance } from "@/i18n/utils";
 
 interface Props {
   title: string;
@@ -13,9 +12,7 @@ interface Props {
 
 const { title, description, href, image, linkText } = Astro.props;
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
+const { t, dir } = Astro.locals;
 
 const defaultLinkText = t("common:components.categoryCard.explore");
 ---

--- a/src/components/ui/ExternalResourceButton.astro
+++ b/src/components/ui/ExternalResourceButton.astro
@@ -1,11 +1,9 @@
 ---
 import externalLinkIcon from "@/assets/icons/mask/external-link.avif";
 import torIcon from "@/assets/icons/mask/tor.avif";
-import { getDirection, getLocale } from "@/i18n/utils";
 import { getPublicImageDimensions } from "@/utils/image";
 import type { HTMLAttributes } from "astro/types";
 import { Image } from "astro:assets";
-import type { TFunction } from "i18next";
 import MaskIcon from "./MaskIcon.astro";
 
 export interface Props extends HTMLAttributes<"div"> {
@@ -15,7 +13,6 @@ export interface Props extends HTMLAttributes<"div"> {
   logo?: string;
   onionHref?: string;
   variant?: "default" | "mini";
-  t?: TFunction;
 }
 
 const {
@@ -25,10 +22,10 @@ const {
   logo,
   onionHref,
   variant = "default",
-  t,
   ...rest
 } = Astro.props;
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const { t, dir } = Astro.locals;
+const rtl = dir === "rtl";
 const logoDimensions = logo ? await getPublicImageDimensions(logo) : null;
 ---
 
@@ -83,14 +80,10 @@ const logoDimensions = logo ? await getPublicImageDimensions(logo) : null;
         target="_blank"
         rel="noopener noreferrer external"
         class="onion-link"
-        title={
-          t?.("common:components.externalResourceButton.onionService") ||
-          "Onion service"
-        }
-        aria-label={
-          t?.("common:components.externalResourceButton.openOnionService") ||
-          "Open onion service"
-        }
+        title={t("common:components.externalResourceButton.onionService")}
+        aria-label={t(
+          "common:components.externalResourceButton.openOnionService",
+        )}
       >
         <MaskIcon src={torIcon} size="1.25em" />
       </a>

--- a/src/components/ui/InternalResourceButton.astro
+++ b/src/components/ui/InternalResourceButton.astro
@@ -1,7 +1,6 @@
 ---
 import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
-import { getDirection, getLocale } from "@/i18n/utils";
 import type { ImageMetadata } from "astro";
 
 interface Props {
@@ -11,7 +10,7 @@ interface Props {
 }
 
 const { icon, title, href } = Astro.props;
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const rtl = Astro.locals.dir === "rtl";
 ---
 
 {

--- a/src/components/ui/PageTabs.astro
+++ b/src/components/ui/PageTabs.astro
@@ -1,5 +1,4 @@
 ---
-import type { TFunction } from "i18next";
 import crypto from "node:crypto";
 
 interface Props {
@@ -8,17 +7,10 @@ interface Props {
   id?: string; // Optional stable id if multiple components on a page
   initial?: number; // 0-based default tab
   activeIndex?: number; // 0-based active tab for navigation mode
-  t: TFunction;
 }
 
-const {
-  labels = [],
-  links,
-  id,
-  initial = 0,
-  activeIndex,
-  t,
-}: Props = Astro.props;
+const { labels = [], links, id, initial = 0, activeIndex }: Props = Astro.props;
+const { t } = Astro.locals;
 if (!Array.isArray(labels) || labels.length === 0) {
   throw new Error("<PageTabs> needs a non-empty labels array.");
 }

--- a/src/components/ui/Paginator.astro
+++ b/src/components/ui/Paginator.astro
@@ -1,8 +1,5 @@
 ---
-import { localizeNumber, getDirection } from "@/i18n/utils";
-import { defaultLocale } from "@/i18n/config";
 import type { Page } from "astro";
-import type { TFunction } from "i18next";
 import MaskIcon from "./MaskIcon.astro";
 
 import chevronLeft from "@/assets/icons/mask/chevron-left.avif";
@@ -10,12 +7,10 @@ import chevronRight from "@/assets/icons/mask/chevron-right.avif";
 
 interface Props {
   page: Page<unknown>;
-  locale?: string;
-  t: TFunction;
 }
 
-const { page, locale, t } = Astro.props;
-const dir = getDirection(locale || defaultLocale);
+const { page } = Astro.props;
+const { t, dir, localizeNumber } = Astro.locals;
 
 const current = page.currentPage;
 const last = page.lastPage;
@@ -101,7 +96,7 @@ const hasNext = current < last;
                 aria-label={t("common:components.paginator.page", { n })}
                 aria-current={isCurrent ? "page" : undefined}
               >
-                {locale ? localizeNumber(locale, n) : n}
+                {localizeNumber(n)}
               </a>
             </li>
           );

--- a/src/components/ui/TitleCard.astro
+++ b/src/components/ui/TitleCard.astro
@@ -1,6 +1,5 @@
 ---
 import chevronLeft from "@/assets/icons/mask/chevron-left.avif";
-import { getDirection, getLocale } from "@/i18n/utils";
 import MaskIcon from "./MaskIcon.astro";
 
 export interface Props {
@@ -19,7 +18,7 @@ const {
   backLabel,
 } = Astro.props;
 
-const rtl = getDirection(getLocale(Astro.url)) === "rtl";
+const rtl = Astro.locals.dir === "rtl";
 ---
 
 <header class:list={[{ centered }]}>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="astro/client" />
+
+declare namespace App {
+  interface Locals {
+    t: import("i18next").TFunction;
+    locale: string;
+    dir: "ltr" | "rtl";
+    localizeHref: (href: string) => string;
+    localizeNumber: (number: number, minimumIntegerDigits?: number) => string;
+    localizeDateString: (
+      date: string | undefined,
+      options?: Intl.DateTimeFormatOptions,
+    ) => string | undefined;
+    safeMarkdown: {
+      parse: (markdown: string) => string;
+      parseInline: (markdown: string) => string;
+    };
+  }
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,23 +2,16 @@
 import Footer from "@/components/layout/Footer.astro";
 import Header from "@/components/layout/header/Header.astro";
 import { locales } from "@/i18n/config";
-import { createTInstance, getDirection, localizeHref } from "@/i18n/utils";
+import { localizeHref } from "@/i18n/utils";
 import "@/styles/external-links.css";
 import "@/styles/global.css";
 import "@/styles/moneropedia-link.css";
 
-import { initMoneropediaCache } from "@/utils/moneropedia";
 import "@fontsource-variable/dm-sans";
 import dmSansFont from "@fontsource-variable/dm-sans/files/dm-sans-latin-wght-normal.woff2?url";
-import { getLocale } from "astro-i18n-aut";
 import { SEO } from "astro-seo";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
-
-// Warm moneropedia cache for this locale
-await initMoneropediaCache(locale);
+const { t, locale, dir } = Astro.locals;
 
 interface Props {
   title: string;
@@ -121,11 +114,11 @@ const fullTitle = title.includes("|")
     <slot name="head" />
   </head>
   <body>
-    <Header t={t} />
+    <Header />
     <main>
       <slot />
     </main>
-    <Footer t={t} />
+    <Footer />
   </body>
 </html>
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,37 @@
+import { defineMiddleware } from "astro:middleware";
+
+import {
+  createTInstance,
+  getDirection,
+  getLocale,
+  localizeDateString,
+  localizeHref as localize,
+  localizeNumber,
+} from "@/i18n/utils";
+import { createSafeMarkdown } from "./utils/safeMarkdown";
+import { initMoneropediaCache } from "@/utils/moneropedia";
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const locale = getLocale(context.url);
+  const t = await createTInstance(locale);
+  const dir = getDirection(locale);
+
+  // Initialize moneropedia cache for this locale
+  await initMoneropediaCache(locale);
+
+  context.locals.t = t;
+  context.locals.locale = locale;
+  context.locals.dir = dir;
+  context.locals.localizeHref = (href: string) => localize(locale, href);
+  context.locals.localizeNumber = (
+    number: number,
+    minimumIntegerDigits?: number,
+  ) => localizeNumber(locale, number, minimumIntegerDigits);
+  context.locals.localizeDateString = (
+    date: string | undefined,
+    options?: Intl.DateTimeFormatOptions,
+  ) => localizeDateString(date, locale, options);
+  context.locals.safeMarkdown = createSafeMarkdown(locale);
+
+  return next();
+});

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,14 +1,7 @@
 ---
-import {
-  createTInstance,
-  getLocale,
-  localizeHref,
-  localizeNumber,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref, localizeNumber } = Astro.locals;
 ---
 
 <Layout
@@ -17,23 +10,22 @@ const t = await createTInstance(locale);
 >
   <div class="error-container">
     <div class="error-content">
-      <h1 class="error-code">{localizeNumber(locale, 404)}</h1>
+      <h1 class="error-code">{localizeNumber(404)}</h1>
       <h2 class="error-title">{t("common:notFound.title")}</h2>
       <p class="error-message">{t("common:notFound.message")}</p>
 
       <nav class="quick-links">
-        <a href={localizeHref(locale, "/")}>{t("common:notFound.links.home")}</a
-        >
-        <a href={localizeHref(locale, "/get-started/what-is-monero/")}
+        <a href={localizeHref("/")}>{t("common:notFound.links.home")}</a>
+        <a href={localizeHref("/get-started/what-is-monero/")}
           >{t("common:notFound.links.whatIsMonero")}</a
         >
-        <a href={localizeHref(locale, "/downloads/")}
+        <a href={localizeHref("/downloads/")}
           >{t("common:notFound.links.downloads")}</a
         >
-        <a href={localizeHref(locale, "/get-started/faq/")}
+        <a href={localizeHref("/get-started/faq/")}
           >{t("common:notFound.links.faq")}</a
         >
-        <a href={localizeHref(locale, "/community/hangouts/")}
+        <a href={localizeHref("/community/hangouts/")}
           >{t("common:notFound.links.community")}</a
         >
       </nav>

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,10 +1,4 @@
 ---
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import { getCollection } from "astro:content";
 
 import Layout from "@/layouts/Layout.astro";
@@ -34,9 +28,7 @@ interface Props {
 const { page } = Astro.props;
 const posts = page.data;
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
+const { t, dir, localizeHref } = Astro.locals;
 
 const tabs = [
   { label: t("blog:tabs.allPosts"), link: "/blog" },
@@ -66,9 +58,8 @@ const tabs = [
     <div class="tabs-bar">
       <PageTabs
         labels={tabs.map((tab) => tab.label)}
-        links={tabs.map((tab) => localizeHref(locale, tab.link))}
+        links={tabs.map((tab) => localizeHref(tab.link))}
         activeIndex={0}
-        t={t}
       />
       <a
         class="rss-icon"
@@ -89,13 +80,11 @@ const tabs = [
             tags={post.data.tags || []}
             image={post.data.image}
             summary={post.data.summary || ""}
-            locale={locale}
-            t={t}
           />
         ))
       }
     </div>
-    <Paginator page={page} locale={locale} t={t} />
+    <Paginator page={page} />
   </PageContainer>
 </Layout>
 

--- a/src/pages/blog/[...post].astro
+++ b/src/pages/blog/[...post].astro
@@ -1,12 +1,6 @@
 ---
 import BlogContent from "@/components/pages/blog/BlogContent.astro";
 import BlogHeader from "@/components/pages/blog/BlogHeader.astro";
-import {
-  createTInstance,
-  getLocale,
-  localizeDateString,
-  localizeHref,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 import { getDateStringFromId } from "@/utils/blog";
 import type { GetStaticPaths } from "astro";
@@ -27,8 +21,7 @@ interface Props {
 }
 
 const { post } = Astro.props;
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref, localizeDateString } = Astro.locals;
 
 const { Content } = await render(post);
 // Get recent posts for the sidebar
@@ -75,8 +68,6 @@ const recentPosts = allPosts.filter((_, i) => i !== currentIndex).slice(0, N);
         id={post.id}
         author={post.data.author}
         tags={post.data.tags}
-        locale={locale}
-        t={t}
       />
       {
         post.data.image && (
@@ -103,7 +94,7 @@ const recentPosts = allPosts.filter((_, i) => i !== currentIndex).slice(0, N);
         {
           recentPosts.map((recentPost) => {
             const dateStr = getDateStringFromId(recentPost.id);
-            const formattedDate = localizeDateString(dateStr ?? "", locale, {
+            const formattedDate = localizeDateString(dateStr, {
               year: "numeric",
               month: "long",
               day: "numeric",
@@ -112,7 +103,7 @@ const recentPosts = allPosts.filter((_, i) => i !== currentIndex).slice(0, N);
               <li>
                 <a
                   class="post-title"
-                  href={localizeHref(locale, `/blog/${recentPost.id}/`)}
+                  href={localizeHref(`/blog/${recentPost.id}/`)}
                 >
                   {recentPost.data.title}
                 </a>

--- a/src/pages/blog/tags/[tag]/[...page].astro
+++ b/src/pages/blog/tags/[tag]/[...page].astro
@@ -4,12 +4,6 @@ import PageContainer from "@/components/ui/PageContainer.astro";
 import PageTabs from "@/components/ui/PageTabs.astro";
 import Paginator from "@/components/ui/Paginator.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 import type { GetStaticPaths, Page } from "astro";
 import type { CollectionEntry } from "astro:content";
@@ -47,9 +41,7 @@ const posts = page.data;
 const sanitizedTag = String(tag).replace(/-/g, " ");
 const pathname = Astro.url.pathname;
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
+const { t, dir, localizeHref } = Astro.locals;
 const translatedTag = t(`blog:tagLabels.${sanitizedTag}`, {
   defaultValue: sanitizedTag,
 });
@@ -62,16 +54,14 @@ const tabs = [
 ];
 
 let activeTab = tabs.findIndex((tab, index) => {
-  const localizedLink = localizeHref(locale, tab.link);
+  const localizedLink = localizeHref(tab.link);
   if (index === 0) {
     return pathname === localizedLink;
   }
   return pathname.startsWith(localizedLink);
 });
 
-const isMainTab = tabs.some(
-  (tab) => pathname == localizeHref(locale, tab.link),
-);
+const isMainTab = tabs.some((tab) => pathname == localizeHref(tab.link));
 const titleKey = isMainTab ? "blog:index.hero.title" : "blog:tags.hero.title";
 ---
 
@@ -99,9 +89,8 @@ const titleKey = isMainTab ? "blog:index.hero.title" : "blog:tags.hero.title";
     <div class="tabs-bar">
       <PageTabs
         labels={tabs.map((tab) => tab.label)}
-        links={tabs.map((tab) => localizeHref(locale, tab.link))}
+        links={tabs.map((tab) => localizeHref(tab.link))}
         activeIndex={activeTab}
-        t={t}
       />
       <a
         class="rss-icon"
@@ -122,13 +111,11 @@ const titleKey = isMainTab ? "blog:index.hero.title" : "blog:tags.hero.title";
             tags={post.data.tags || []}
             image={post.data.image}
             summary={post.data.summary || ""}
-            locale={locale}
-            t={t}
           />
         ))
       }
     </div>
-    <Paginator page={page} locale={locale} t={t} />
+    <Paginator page={page} />
   </PageContainer>
 </Layout>
 

--- a/src/pages/blog/tags/index.astro
+++ b/src/pages/blog/tags/index.astro
@@ -1,7 +1,6 @@
 ---
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 import { getCollection } from "astro:content";
 
@@ -9,8 +8,7 @@ const allPosts = await getCollection("blog");
 const tags = [...new Set(allPosts.flatMap((post) => post.data.tags))].filter(
   (tag) => tag !== undefined,
 );
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -36,7 +34,6 @@ const t = await createTInstance(locale);
           <li>
             <a
               href={localizeHref(
-                locale,
                 `/blog/tags/${tag.toLowerCase().replace(/\s+/g, "-")}/`,
               )}
             >

--- a/src/pages/community/hangouts.astro
+++ b/src/pages/community/hangouts.astro
@@ -5,15 +5,13 @@ import InternalResourceButton from "@/components/ui/InternalResourceButton.astro
 import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import usersIcon from "@/assets/icons/mask/users.avif";
 
 import { channels, chatLinks, socialLinks } from "@/data/hangouts";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout title={t("hangouts:pageTitle")} description={t("hangouts:description")}>
@@ -25,7 +23,7 @@ const t = await createTInstance(locale);
     <InternalResourceButton
       icon={usersIcon}
       title={t("hangouts:workgroupsNote.title")}
-      href={localizeHref(locale, "/community/workgroups")}
+      href={localizeHref("/community/workgroups")}
     >
       {t("hangouts:workgroupsNote.content")}
     </InternalResourceButton>
@@ -41,7 +39,6 @@ const t = await createTInstance(locale);
                   title={t(link.titleKey)}
                   subtitle={link.subtitleKey ? t(link.subtitleKey) : undefined}
                   logo={link.logo}
-                  t={t}
                 />
               </li>
             ))
@@ -59,7 +56,6 @@ const t = await createTInstance(locale);
                   title={t(link.titleKey)}
                   subtitle={link.subtitleKey ? t(link.subtitleKey) : undefined}
                   logo={link.logo}
-                  t={t}
                 />
               </li>
             ))
@@ -80,7 +76,6 @@ const t = await createTInstance(locale);
                 description={t(ch.descriptionKey)}
                 href={ch.href}
                 matrixHref={ch.matrixHref}
-                t={t}
               />
             </li>
           ))

--- a/src/pages/community/sponsorships.astro
+++ b/src/pages/community/sponsorships.astro
@@ -6,14 +6,12 @@ import CTACard from "@/components/ui/CTACard.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale } from "@/i18n/utils";
 
 import { currentSponsors, pastSponsors } from "@/data/sponsors";
 
 import heartPlusIcon from "@/assets/icons/mask/heartPlus.avif";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t } = Astro.locals;
 ---
 
 <Layout

--- a/src/pages/community/workgroups.astro
+++ b/src/pages/community/workgroups.astro
@@ -7,12 +7,6 @@ import MaskIcon from "@/components/ui/MaskIcon.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import communityLogo from "@/assets/images/community-logo.avif";
@@ -27,9 +21,7 @@ import {
   researchWorkgroups,
 } from "@/data/workgroups";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
+const { t, dir, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -45,7 +37,7 @@ const dir = getDirection(locale);
     <InternalResourceButton
       icon={messageCircleIcon}
       title={t("workgroups:hangoutsNote.title")}
-      href={localizeHref(locale, "/community/hangouts")}
+      href={localizeHref("/community/hangouts")}
     >
       {t("workgroups:hangoutsNote.content")}
     </InternalResourceButton>
@@ -97,7 +89,6 @@ const dir = getDirection(locale);
                 chatName={wg.chatName}
                 ircHref={wg.ircHref}
                 matrixHref={wg.matrixHref}
-                t={t}
               />
             ))
           }
@@ -121,7 +112,6 @@ const dir = getDirection(locale);
                 chatName={wg.chatName}
                 ircHref={wg.ircHref}
                 matrixHref={wg.matrixHref}
-                t={t}
               />
             ))
           }
@@ -145,7 +135,6 @@ const dir = getDirection(locale);
                 chatName={wg.chatName}
                 ircHref={wg.ircHref}
                 matrixHref={wg.matrixHref}
-                t={t}
               />
             ))
           }

--- a/src/pages/downloads/community.astro
+++ b/src/pages/downloads/community.astro
@@ -1,6 +1,4 @@
 ---
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
-
 import Layout from "@/layouts/Layout.astro";
 
 import CommunityCard from "@/components/pages/downloads/CommunityCard.astro";
@@ -41,13 +39,12 @@ export const sortWallets = (wallets: Wallet[]) =>
     return count(b) - count(a) || a.name.localeCompare(b.name);
   });
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 const tabs = [
-  { label: t("downloads:tabs.core"), link: localizeHref(locale, "/downloads") },
+  { label: t("downloads:tabs.core"), link: localizeHref("/downloads") },
   {
     label: t("downloads:tabs.community"),
-    link: localizeHref(locale, "/downloads/community"),
+    link: localizeHref("/downloads/community"),
   },
 ];
 
@@ -98,7 +95,6 @@ const setBuiltinId = (wallet: Wallet) => {
       labels={tabs.map((tab) => tab.label)}
       links={tabs.map((tab) => tab.link)}
       activeIndex={1}
-      t={t}
     />
 
     <TOCContainer
@@ -128,7 +124,6 @@ const setBuiltinId = (wallet: Wallet) => {
               translateTag={(key: string) =>
                 t(`downloads:community.tags.${key}`)
               }
-              t={t}
               id={setBuiltinId(wallet)}
             />
           ))
@@ -151,7 +146,6 @@ const setBuiltinId = (wallet: Wallet) => {
               translateTag={(key: string) =>
                 t(`downloads:community.tags.${key}`)
               }
-              t={t}
               id={setBuiltinId(wallet)}
             />
           ))
@@ -177,7 +171,6 @@ const setBuiltinId = (wallet: Wallet) => {
               translateTag={(key: string) =>
                 t(`downloads:community.tags.${key}`)
               }
-              t={t}
               id={setBuiltinId(wallet)}
             />
           ))
@@ -206,7 +199,6 @@ const setBuiltinId = (wallet: Wallet) => {
               translateTag={(key: string) =>
                 t(`downloads:community.tags.${key}`)
               }
-              t={t}
               id={setBuiltinId(wallet)}
             />
           ))
@@ -235,7 +227,6 @@ const setBuiltinId = (wallet: Wallet) => {
               translateTag={(key: string) =>
                 t(`downloads:community.tags.${key}`)
               }
-              t={t}
               id={setBuiltinId(wallet)}
             />
           ))

--- a/src/pages/downloads/index.astro
+++ b/src/pages/downloads/index.astro
@@ -1,7 +1,4 @@
 ---
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown.ts";
-
 import Layout from "@/layouts/Layout.astro";
 
 import type { DownloadLink } from "@/components/pages/downloads/CoreCard.astro";
@@ -20,15 +17,13 @@ import guiImage from "@/assets/images/gui.avif";
 
 import PageContainer from "@/components/ui/PageContainer.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const safeMarkdown = createSafeMarkdown();
+const { t, localizeHref, safeMarkdown } = Astro.locals;
 
 const tabs = [
-  { label: t("downloads:tabs.core"), link: localizeHref(locale, "/downloads") },
+  { label: t("downloads:tabs.core"), link: localizeHref("/downloads") },
   {
     label: t("downloads:tabs.community"),
-    link: localizeHref(locale, "/downloads/community"),
+    link: localizeHref("/downloads/community"),
   },
 ];
 ---
@@ -46,12 +41,11 @@ const tabs = [
       labels={tabs.map((tab) => tab.label)}
       links={tabs.map((tab) => tab.link)}
       activeIndex={0}
-      t={t}
     />
     <InternalResourceButton
       icon={walletIcon}
       title={t("downloads:communityNote.title")}
-      href={localizeHref(locale, "/downloads/community")}
+      href={localizeHref("/downloads/community")}
     >
       {t("downloads:communityNote.content")}
     </InternalResourceButton>
@@ -75,7 +69,6 @@ const tabs = [
           >,
         )}
         downloads={coreDownloads.gui.downloads as DownloadLink[]}
-        t={t}
       />
 
       <!-- Monero CLI Card -->
@@ -97,7 +90,6 @@ const tabs = [
           >,
         )}
         downloads={coreDownloads.cli.downloads as DownloadLink[]}
-        t={t}
       />
     </div>
 

--- a/src/pages/get-started/accept-monero.astro
+++ b/src/pages/get-started/accept-monero.astro
@@ -15,17 +15,7 @@ import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import handCoinsIcon from "@/assets/icons/mask/handCoins.avif";
 import usersIcon from "@/assets/icons/mask/users.avif";
 
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-  localizeNumber,
-} from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
+const { t, dir, localizeHref, localizeNumber } = Astro.locals;
 ---
 
 <Layout
@@ -40,10 +30,9 @@ const dir = getDirection(locale);
   <PageContainer>
     <div class="guide-content">
       <GuideStep
-        step={localizeNumber(locale, 1)}
+        step={localizeNumber(1)}
         title={t("accept-monero:steps.chooseSetup.title")}
         icon={appWindowIcon}
-        t={t}
       >
         <p>{t("accept-monero:steps.chooseSetup.intro")}</p>
 
@@ -58,7 +47,7 @@ const dir = getDirection(locale);
               {t("accept-monero:steps.chooseSetup.wallet.description")}
             </p>
             <a
-              href={localizeHref(locale, "/downloads/community/#wallets")}
+              href={localizeHref("/downloads/community/#wallets")}
               class="inline-link"
             >
               {t("accept-monero:steps.chooseSetup.wallet.viewWallets")}
@@ -101,7 +90,7 @@ const dir = getDirection(locale);
               {t("accept-monero:steps.chooseSetup.processor.description")}
             </p>
             <a
-              href={localizeHref(locale, "/resources/tools/accept/")}
+              href={localizeHref("/resources/tools/accept/")}
               class="inline-link"
             >
               {t("accept-monero:steps.chooseSetup.processor.viewGateways")}
@@ -147,11 +136,10 @@ const dir = getDirection(locale);
       <hr />
 
       <GuideStep
-        step={localizeNumber(locale, 2)}
+        step={localizeNumber(2)}
         title={t("accept-monero:steps.acceptPayment.title")}
         icon={handCoinsIcon}
         reverse
-        t={t}
       >
         <p>
           {t("accept-monero:steps.acceptPayment.description")}
@@ -170,18 +158,14 @@ const dir = getDirection(locale);
       <hr />
 
       <GuideStep
-        step={localizeNumber(locale, 3)}
+        step={localizeNumber(3)}
         title={t("accept-monero:steps.getListed.title")}
         icon={usersIcon}
-        t={t}
       >
         <p>
           {t("accept-monero:steps.getListed.description")}
         </p>
-        <a
-          href={localizeHref(locale, "/get-started/merchants")}
-          class="inline-link"
-        >
+        <a href={localizeHref("/get-started/merchants")} class="inline-link">
           {t("accept-monero:steps.getListed.viewDirectories")}
           <MaskIcon src={arrowRightIcon} size="1em" rtl={dir == "rtl"} />
         </a>

--- a/src/pages/get-started/contribute/develop.astro
+++ b/src/pages/get-started/contribute/develop.astro
@@ -17,16 +17,7 @@ import shieldCheckIcon from "@/assets/icons/mask/shieldCheck.avif";
 import terminalIcon from "@/assets/icons/mask/terminal.avif";
 import usersIcon from "@/assets/icons/mask/users.avif";
 
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
+const { dir, t, localizeHref } = Astro.locals;
 
 const coreProjects = [
   {
@@ -88,7 +79,7 @@ const communityProjects = [
   <TitleCard
     title={t("contribute:develop.title")}
     subtitle={t("contribute:develop.subtitle")}
-    backHref={localizeHref(locale, "/get-started/contribute/")}
+    backHref={localizeHref("/get-started/contribute/")}
     backLabel={t("contribute:index.title")}
   />
 
@@ -217,10 +208,7 @@ const communityProjects = [
           <p class="sidebar-subtitle">
             {t("contribute:develop.workgroups.description")}
           </p>
-          <a
-            href={localizeHref(locale, "/community/workgroups/")}
-            class="sidebar-item"
-          >
+          <a href={localizeHref("/community/workgroups/")} class="sidebar-item">
             <span class="sidebar-item-icon">
               <MaskIcon src={usersIcon} size="1.25rem" />
             </span>
@@ -254,7 +242,7 @@ const communityProjects = [
             </span>
           </a>
           <a
-            href={localizeHref(locale, "/resources/tools/develop/")}
+            href={localizeHref("/resources/tools/develop/")}
             class="sidebar-item"
           >
             <span class="sidebar-item-icon">

--- a/src/pages/get-started/contribute/donate.astro
+++ b/src/pages/get-started/contribute/donate.astro
@@ -14,16 +14,7 @@ import communityLogo from "@/assets/images/idea-bulb.avif";
 
 import contributingData from "@/data/contributing/contributing.json";
 
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
+const { dir, t, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -33,7 +24,7 @@ const t = await createTInstance(locale);
   <TitleCard
     title={t("contribute:donate.title")}
     subtitle={t("contribute:donate.subtitle")}
-    backHref={localizeHref(locale, "/get-started/contribute/")}
+    backHref={localizeHref("/get-started/contribute/")}
     backLabel={t("contribute:index.title")}
   />
 

--- a/src/pages/get-started/contribute/index.astro
+++ b/src/pages/get-started/contribute/index.astro
@@ -2,27 +2,25 @@
 import CategoryCard from "@/components/ui/CategoryCard.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 
 const cards = [
   {
     title: t("contribute:network.title"),
     description: t("contribute:network.subtitle"),
-    href: localizeHref(locale, "/get-started/contribute/network"),
+    href: localizeHref("/get-started/contribute/network"),
   },
   {
     title: t("contribute:develop.title"),
     description: t("contribute:develop.subtitle"),
-    href: localizeHref(locale, "/get-started/contribute/develop"),
+    href: localizeHref("/get-started/contribute/develop"),
   },
   {
     title: t("contribute:donate.title"),
     description: t("contribute:donate.subtitle"),
-    href: localizeHref(locale, "/get-started/contribute/donate"),
+    href: localizeHref("/get-started/contribute/donate"),
   },
 ];
 ---

--- a/src/pages/get-started/contribute/network.astro
+++ b/src/pages/get-started/contribute/network.astro
@@ -12,18 +12,7 @@ import externalLinkIcon from "@/assets/icons/mask/external-link.avif";
 import moneroPickaxe from "@/assets/images/monero_pickaxe.webp";
 import serverImage from "@/assets/images/server.avif";
 
-import {
-  createTInstance,
-  getLocale,
-  localizeHref,
-  getDirection,
-} from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
-
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { t, dir, localizeHref, safeMarkdown } = Astro.locals;
 ---
 
 <Layout
@@ -33,7 +22,7 @@ const safeMarkdown = createSafeMarkdown(locale);
   <TitleCard
     title={t("contribute:network.title")}
     subtitle={t("contribute:network.subtitle")}
-    backHref={localizeHref(locale, "/get-started/contribute/")}
+    backHref={localizeHref("/get-started/contribute/")}
     backLabel={t("contribute:index.title")}
   />
 
@@ -52,7 +41,7 @@ const safeMarkdown = createSafeMarkdown(locale);
           <li>{t("contribute:network.mine.bullets.convertCpuPower")}</li>
         </ul>
         <div class="cta-links">
-          <Button href={localizeHref(locale, "/get-started/mining/")}>
+          <Button href={localizeHref("/get-started/mining/")}>
             {t("contribute:network.mine.learnAboutMining")}
             <MaskIcon src={arrowRight} size="1em" rtl={dir == "rtl"} />
           </Button>

--- a/src/pages/get-started/exchanges.astro
+++ b/src/pages/get-started/exchanges.astro
@@ -3,12 +3,6 @@ import DisclaimerNote from "@/components/ui/DisclaimerNote.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import bankIcon from "@/assets/icons/mask/bank.avif";
@@ -26,12 +20,7 @@ import TOCItem from "@/components/ui/TOCItem.astro";
 
 import exchanges from "@/data/exchanges";
 
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
-
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { dir, t, localizeHref, safeMarkdown } = Astro.locals;
 
 const highlightOptions = [
   {
@@ -153,7 +142,6 @@ const highlightOptions = [
             <ExchangeTable
               exchanges={exchanges.decentralizedExchanges}
               hasKyc={false}
-              t={t}
             />
           </PageSection>
 
@@ -177,14 +165,12 @@ const highlightOptions = [
               subtitle={t("exchanges:sections.aggregators.resourceBtnSubtitle")}
               logo="/media/directories/kycnotme.jpg"
               data-highlight="user-friendly crypto"
-              t={t}
             />
             <p
               style="color: var(--paragraph-subtitle);"
               set:html={safeMarkdown.parseInline(
                 t("exchanges:sections.aggregators.tip", {
                   communityDownloadsUrl: localizeHref(
-                    locale,
                     "/downloads/community/#built-in-exchange",
                   ),
                 }),
@@ -202,7 +188,6 @@ const highlightOptions = [
             <ExchangeTable
               exchanges={exchanges.centralizedExchanges}
               hasKyc={true}
-              t={t}
             />
           </PageSection>
         </div>

--- a/src/pages/get-started/faq.astro
+++ b/src/pages/get-started/faq.astro
@@ -1,9 +1,6 @@
 ---
 import "@/styles/moneropedia-link.css";
 
-import { createTInstance, getLocale } from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
-
 import Layout from "@/layouts/Layout.astro";
 
 import IndexCard from "@/components/pages/index/IndexCard.astro";
@@ -16,9 +13,7 @@ import developerGuidesIcon from "@/assets/icons/mask/developer-guides.avif";
 import faqIcon from "@/assets/icons/mask/faq.avif";
 import PageContainer from "@/components/ui/PageContainer.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { t, safeMarkdown } = Astro.locals;
 
 const sectionToItems = (
   section: Record<string, { title: string; content: string }>,

--- a/src/pages/get-started/merchants.astro
+++ b/src/pages/get-started/merchants.astro
@@ -4,15 +4,13 @@ import Layout from "@/layouts/Layout.astro";
 import ExternalResourceButton from "@/components/ui/ExternalResourceButton.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale } from "@/i18n/utils";
 
 import merchants from "@/data/merchants";
 
 import shieldIcon from "@/assets/icons/mask/shieldAlert.avif";
 import DisclaimerBar from "@/components/ui/DisclaimerBar.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t } = Astro.locals;
 ---
 
 <Layout
@@ -40,7 +38,6 @@ const t = await createTInstance(locale);
               title={merchant.name}
               subtitle={t(`merchants:subtitles.${merchant.id}`)}
               logo={merchant.logo}
-              t={t}
             />
           ))
       }

--- a/src/pages/get-started/mining.astro
+++ b/src/pages/get-started/mining.astro
@@ -9,7 +9,6 @@ import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import PageSectionColumn from "@/components/ui/PageSectionColumn.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, getDirection } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import appWindowIcon from "@/assets/icons/mask/app-window.avif";
@@ -21,12 +20,8 @@ import terminalIcon from "@/assets/icons/mask/terminal.avif";
 import guiWindow from "@/assets/images/gui.avif";
 import gupaxWindow from "@/assets/images/gupax-window.webp";
 import xmrigWindow from "@/assets/images/xmrig-window.avif";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const dir = getDirection(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { t, dir, safeMarkdown } = Astro.locals;
 
 // Helper to convert keyed FAQ section to array for Accordion
 const faqToItems = (

--- a/src/pages/get-started/what-is-monero.astro
+++ b/src/pages/get-started/what-is-monero.astro
@@ -22,22 +22,12 @@ import shieldPlusIcon from "@/assets/icons/mask/shieldPlus.avif";
 import arrowRight from "@/assets/icons/mask/arrow-right.avif";
 
 import Button from "@/components/ui/Button.astro";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  getLocaleName,
-  localizeHref,
-} from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
+import { getLocaleName } from "@/i18n/utils";
 
 import { readdirSync } from "fs";
 import { join } from "path";
 
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { t, dir, localizeHref, safeMarkdown } = Astro.locals;
 
 const i18nVttFiles = readdirSync(
   join(process.cwd(), "public", "media", "vtt", "msmsm"),
@@ -234,7 +224,6 @@ const getLanguageLabel = (lang: string): string => {
                 "what-is-monero:sections.technology.features.stealthAddresses.basedOn",
                 {
                   mpECDH: localizeHref(
-                    locale,
                     "/resources/moneropedia/elliptic-curve-diffie-hellman/",
                   ),
                 },
@@ -255,7 +244,6 @@ const getLanguageLabel = (lang: string): string => {
             set:html={safeMarkdown.parseInline(
               t("what-is-monero:sections.technology.features.fcmp.basedOn", {
                 mpCurveTrees: localizeHref(
-                  locale,
                   "/resources/moneropedia/curve-trees/",
                 ),
               }),
@@ -287,11 +275,9 @@ const getLanguageLabel = (lang: string): string => {
                 "what-is-monero:sections.technology.features.confidentialTransactions.basedOn",
                 {
                   mpPedersenCommitments: localizeHref(
-                    locale,
                     "/resources/moneropedia/pedersen-commitment/",
                   ),
                   mpBulletproofs: localizeHref(
-                    locale,
                     "/resources/moneropedia/bulletproofs/",
                   ),
                 },
@@ -351,19 +337,19 @@ const getLanguageLabel = (lang: string): string => {
         <p
           set:html={safeMarkdown.parseInline(
             t("what-is-monero:sections.community.content", {
-              mrlLink: localizeHref(locale, "/resources/research-lab/"),
+              mrlLink: localizeHref("/resources/research-lab/"),
             }),
           )}
         />
         <div class="community-cta-links">
           <a
-            href={localizeHref(locale, "/community/hangouts/")}
+            href={localizeHref("/community/hangouts/")}
             aria-label={t("what-is-monero:sections.community.joinCommunity")}
             >{t("what-is-monero:sections.community.joinCommunity")}
             <MaskIcon src={arrowRight} size="1em" rtl={dir == "rtl"} /></a
           >
           <a
-            href={localizeHref(locale, "/community/workgroups/")}
+            href={localizeHref("/community/workgroups/")}
             aria-label={t(
               "what-is-monero:sections.community.contributeToMonero",
             )}
@@ -386,13 +372,13 @@ const getLanguageLabel = (lang: string): string => {
       <Fragment slot="buttons">
         <Button
           variant="primary"
-          href={localizeHref(locale, "/downloads/community/#wallets")}
+          href={localizeHref("/downloads/community/#wallets")}
         >
           {t("what-is-monero:sections.cta.downloadWallet")}
         </Button>
         <Button
           variant="secondary"
-          href={localizeHref(locale, "/get-started/exchanges/")}
+          href={localizeHref("/get-started/exchanges/")}
         >
           {t("what-is-monero:sections.cta.getMonero")}
         </Button>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,4 @@
 ---
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
-
 import Layout from "@/layouts/Layout.astro";
 
 import GetStartedCard from "@/components/pages/index/GetStartedCard.astro";
@@ -15,12 +13,11 @@ import usersIcon from "@/assets/icons/mask/users.avif";
 import landingImage from "@/assets/images/landing.avif";
 import { Image } from "astro:assets";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout title={t("index:pageTitle")} description={t("index:hero.lead")}>
-  <Hero t={t} class="index-hero" />
+  <Hero class="index-hero" />
   <div class="main-content">
     <IndexCard
       id="about-monero"
@@ -74,7 +71,7 @@ const t = await createTInstance(locale);
           step="01"
           title={t("index:step1Title")}
           description={t("index:step1Desc")}
-          ctaHref={localizeHref(locale, "/downloads/community/#wallets")}
+          ctaHref={localizeHref("/downloads/community/#wallets")}
           ctaLabel={t("index:step1Cta")}
         />
         <hr />
@@ -82,7 +79,7 @@ const t = await createTInstance(locale);
           step="02"
           title={t("index:step2Title")}
           description={t("index:step2Desc")}
-          ctaHref={localizeHref(locale, "/get-started/exchanges")}
+          ctaHref={localizeHref("/get-started/exchanges")}
           ctaLabel={t("index:step2Cta")}
         />
         <hr />
@@ -90,7 +87,7 @@ const t = await createTInstance(locale);
           step="03"
           title={t("index:step3Title")}
           description={t("index:step3Desc")}
-          ctaHref={localizeHref(locale, "/get-started/merchants")}
+          ctaHref={localizeHref("/get-started/merchants")}
           ctaLabel={t("index:step3Cta")}
         />
       </div>
@@ -106,21 +103,21 @@ const t = await createTInstance(locale);
           title={t("index:hangoutsTitle")}
           description={t("index:hangoutsDesc")}
           ctaLabel={t("index:hangoutsCta")}
-          ctaHref={localizeHref(locale, "/community/hangouts")}
+          ctaHref={localizeHref("/community/hangouts")}
           icon={chatIcon}
         />
         <ResourceCard
           title={t("index:workgroupsTitle")}
           description={t("index:workgroupsDesc")}
           ctaLabel={t("index:workgroupsCta")}
-          ctaHref={localizeHref(locale, "/community/workgroups")}
+          ctaHref={localizeHref("/community/workgroups")}
           icon={usersIcon}
         />
         <ResourceCard
           title={t("index:contributeTitle")}
           description={t("index:contributeDesc")}
           ctaLabel={t("index:contributeCta")}
-          ctaHref={localizeHref(locale, "/get-started/contribute")}
+          ctaHref={localizeHref("/get-started/contribute")}
           icon={codeIcon}
         />
       </div>

--- a/src/pages/legal.astro
+++ b/src/pages/legal.astro
@@ -10,10 +10,7 @@ import copyrightIcon from "@/assets/icons/mask/copyright.avif";
 import receiptTextIcon from "@/assets/icons/mask/receiptText.avif";
 import shieldCheckIcon from "@/assets/icons/mask/shieldCheck.avif";
 
-import { createTInstance, getLocale } from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t } = Astro.locals;
 
 const sections = [
   {

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -2,27 +2,25 @@
 import CategoryCard from "@/components/ui/CategoryCard.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 
 const cards = [
   {
     title: t("knowledge-base:library.title"),
     description: t("knowledge-base:library.cardSubtitle"),
-    href: localizeHref(locale, "/resources/library/"),
+    href: localizeHref("/resources/library/"),
   },
   {
     title: t("knowledge-base:moneropedia.title"),
     description: t("knowledge-base:moneropedia.cardSubtitle"),
-    href: localizeHref(locale, "/resources/moneropedia/"),
+    href: localizeHref("/resources/moneropedia/"),
   },
   {
     title: t("knowledge-base:researchLab.title"),
     description: t("knowledge-base:researchLab.cardSubtitle"),
-    href: localizeHref(locale, "/resources/research-lab"),
+    href: localizeHref("/resources/research-lab"),
   },
 ];
 ---

--- a/src/pages/resources/knowledge-base.astro
+++ b/src/pages/resources/knowledge-base.astro
@@ -2,27 +2,25 @@
 import CategoryCard from "@/components/ui/CategoryCard.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 
 const cards = [
   {
     title: t("knowledge-base:library.title"),
     description: t("knowledge-base:library.cardSubtitle"),
-    href: localizeHref(locale, "/resources/library/"),
+    href: localizeHref("/resources/library/"),
   },
   {
     title: t("knowledge-base:moneropedia.title"),
     description: t("knowledge-base:moneropedia.cardSubtitle"),
-    href: localizeHref(locale, "/resources/moneropedia/"),
+    href: localizeHref("/resources/moneropedia/"),
   },
   {
     title: t("knowledge-base:researchLab.title"),
     description: t("knowledge-base:researchLab.cardSubtitle"),
-    href: localizeHref(locale, "/resources/research-lab"),
+    href: localizeHref("/resources/research-lab"),
   },
 ];
 ---

--- a/src/pages/resources/library/index.astro
+++ b/src/pages/resources/library/index.astro
@@ -10,21 +10,12 @@ import Layout from "@/layouts/Layout.astro";
 
 import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import bookTextIcon from "@/assets/icons/mask/bookText.avif";
-import receiptTextIcon from "@/assets/icons/mask/receiptText.avif";
 import mailsIcon from "@/assets/icons/mask/mails.avif";
+import receiptTextIcon from "@/assets/icons/mask/receiptText.avif";
 
 import { books, cheatsheets, newsletters } from "@/data/library";
 
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
+const { dir, t, localizeHref } = Astro.locals;
 
 const sections = [
   {
@@ -55,7 +46,7 @@ const sections = [
   <TitleCard
     title={t("knowledge-base:library.title")}
     subtitle={t("knowledge-base:library.subtitle")}
-    backHref={localizeHref(locale, "/resources/knowledge-base/")}
+    backHref={localizeHref("/resources/knowledge-base/")}
     backLabel={t("knowledge-base:index.title")}
   />
 
@@ -70,7 +61,7 @@ const sections = [
       anchorId="books"
     >
       <div class="books-shelf">
-        {books.map((book) => <BookCard {...book} t={t} />)}
+        {books.map((book) => <BookCard {...book} />)}
       </div>
     </PageSection>
 
@@ -136,7 +127,6 @@ const sections = [
               href={newsletter.url}
               title={newsletter.title}
               subtitle={newsletter.description}
-              t={t}
             />
           ))
         }

--- a/src/pages/resources/moneropedia/[...slug].astro
+++ b/src/pages/resources/moneropedia/[...slug].astro
@@ -1,11 +1,5 @@
 ---
 import { defaultLocale } from "@/i18n/config";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import type { CollectionEntry } from "astro:content";
 import { getCollection, getEntry, render } from "astro:content";
 
@@ -27,10 +21,9 @@ export async function getStaticPaths() {
 
 type Props = CollectionEntry<"moneropedia">;
 
+const { locale, t, dir, localizeHref } = Astro.locals;
+
 const { slug } = Astro.params;
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
 const entry = await getEntry("moneropedia", `${locale}/${slug}`);
 
 if (!entry) {
@@ -52,7 +45,7 @@ const title = entry.data.title ?? entry.data.terms[0];
     {/* Row 1, Col 1 */}
     <aside class="moneropedia-sidebar">
       <a
-        href={localizeHref(locale, "/resources/moneropedia/")}
+        href={localizeHref("/resources/moneropedia/")}
         class="moneropedia-back"
       >
         <span class="moneropedia-back-icon">

--- a/src/pages/resources/moneropedia/index.astro
+++ b/src/pages/resources/moneropedia/index.astro
@@ -1,6 +1,4 @@
 ---
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
-import { createSafeMarkdown } from "@/utils/safeMarkdown";
 import type { CollectionEntry } from "astro:content";
 import { getCollection } from "astro:content";
 
@@ -16,9 +14,7 @@ type MoneropediaItem = CollectionEntry<"moneropedia"> & {
   letter: string;
 };
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
-const safeMarkdown = createSafeMarkdown(locale);
+const { locale, t, localizeHref, safeMarkdown } = Astro.locals;
 
 const entries = (
   await getCollection("moneropedia", (entry) =>
@@ -34,7 +30,7 @@ const entries = (
 
   return {
     ...entry,
-    href: localizeHref(locale, `/resources/moneropedia/${slug}/`),
+    href: localizeHref(`/resources/moneropedia/${slug}/`),
     title,
     letter: title.charAt(0).toUpperCase(),
   };
@@ -60,7 +56,7 @@ for (const letter of sortedLetters) {
   <TitleCard
     title={t("knowledge-base:moneropedia.title")}
     subtitle={t("knowledge-base:moneropedia.subtitle")}
-    backHref={localizeHref(locale, "/resources/knowledge-base/")}
+    backHref={localizeHref("/resources/knowledge-base/")}
     backLabel={t("knowledge-base:index.title")}
   />
   <PageContainer class="moneropedia-index">

--- a/src/pages/resources/press-kit.astro
+++ b/src/pages/resources/press-kit.astro
@@ -1,5 +1,4 @@
 ---
-import { Image } from "astro:assets";
 import Button from "@/components/ui/Button.astro";
 import ExternalResourceButton from "@/components/ui/ExternalResourceButton.astro";
 import MaskIcon from "@/components/ui/MaskIcon.astro";
@@ -9,6 +8,7 @@ import PageSectionColumn from "@/components/ui/PageSectionColumn.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 import TOCContainer from "@/components/ui/TOCContainer.astro";
 import Layout from "@/layouts/Layout.astro";
+import { Image } from "astro:assets";
 
 import arrowRightIcon from "@/assets/icons/mask/arrow-right.avif";
 import bookTextIcon from "@/assets/icons/mask/bookText.avif";
@@ -20,17 +20,9 @@ import {
   marketingResources,
   pressDocuments,
 } from "@/data/press-kit";
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
 import { getPublicImageDimensions } from "@/utils/image";
 
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
+const { dir, t, localizeHref } = Astro.locals;
 const previewDimensions = await Promise.all(
   brandAssets.map((asset) => getPublicImageDimensions(asset.preview)),
 );
@@ -202,7 +194,7 @@ const sections = [
             <h3>{t("press-kit:sections.contacts.workgroups.title")}</h3>
             <p>{t("press-kit:sections.contacts.workgroups.description")}</p>
             <a
-              href={localizeHref(locale, "/community/workgroups")}
+              href={localizeHref("/community/workgroups")}
               class="contact-link"
             >
               {t("press-kit:sections.contacts.workgroups.link")}
@@ -212,10 +204,7 @@ const sections = [
           <div class="contact-card">
             <h3>{t("press-kit:sections.contacts.community.title")}</h3>
             <p>{t("press-kit:sections.contacts.community.description")}</p>
-            <a
-              href={localizeHref(locale, "/community/hangouts")}
-              class="contact-link"
-            >
+            <a href={localizeHref("/community/hangouts")} class="contact-link">
               {t("press-kit:sections.contacts.community.link")}
               <MaskIcon src={arrowRightIcon} rtl={dir === "rtl"} />
             </a>

--- a/src/pages/resources/research-lab.astro
+++ b/src/pages/resources/research-lab.astro
@@ -16,16 +16,7 @@ import hashtagIcon from "@/assets/icons/mask/hashtag.avif";
 
 import mrlLogo from "@/assets/images/mrl-logo.avif";
 
-import {
-  createTInstance,
-  getDirection,
-  getLocale,
-  localizeHref,
-} from "@/i18n/utils";
-
-const locale = getLocale(Astro.url);
-const dir = getDirection(locale);
-const t = await createTInstance(locale);
+const { dir, t, localizeHref } = Astro.locals;
 
 import {
   iacrPapers,
@@ -57,7 +48,7 @@ const paperTabs = [
   <TitleCard
     title={t("knowledge-base:researchLab.title")}
     subtitle={t("knowledge-base:researchLab.subtitle")}
-    backHref={localizeHref(locale, "/resources/knowledge-base/")}
+    backHref={localizeHref("/resources/knowledge-base/")}
     backLabel={t("knowledge-base:index.title")}
   />
 
@@ -118,7 +109,6 @@ const paperTabs = [
                     abstract={paper.abstract}
                     url={paper.url}
                     note={paper.note}
-                    t={t}
                   />
                 ))
               }
@@ -132,7 +122,6 @@ const paperTabs = [
                     abstract={paper.abstract}
                     url={paper.url}
                     note={paper.note}
-                    t={t}
                   />
                 ))
               }
@@ -146,7 +135,6 @@ const paperTabs = [
                     abstract={paper.abstract}
                     url={paper.url}
                     note={paper.note}
-                    t={t}
                   />
                 ))
               }

--- a/src/pages/resources/roadmap.astro
+++ b/src/pages/resources/roadmap.astro
@@ -7,10 +7,8 @@ import TitleCard from "@/components/ui/TitleCard.astro";
 import Layout from "@/layouts/Layout.astro";
 
 import roadmapData from "@/data/roadmap";
-import { createTInstance, getLocale } from "@/i18n/utils";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t } = Astro.locals;
 const { items, history } = roadmapData;
 ---
 
@@ -28,7 +26,7 @@ const { items, history } = roadmapData;
             <span class="label-dot active"></span>
             <h2>{t("roadmap:status.inProgress")}</h2>
           </header>
-          <StatusSection items={items} status="in-progress" t={t} />
+          <StatusSection items={items} status="in-progress" />
         </div>
 
         <div class="kanban-column">
@@ -36,7 +34,7 @@ const { items, history } = roadmapData;
             <span class="label-dot upcoming"></span>
             <h2>{t("roadmap:status.upcoming")}</h2>
           </header>
-          <StatusSection items={items} status="upcoming" t={t} />
+          <StatusSection items={items} status="upcoming" />
         </div>
 
         <div class="kanban-column proposed">
@@ -44,14 +42,14 @@ const { items, history } = roadmapData;
             <span class="label-dot proposed"></span>
             <h2>{t("roadmap:status.proposed")}</h2>
           </header>
-          <StatusSection items={items} status="proposed" t={t} />
+          <StatusSection items={items} status="proposed" />
         </div>
       </section>
 
       <hr aria-hidden="true" />
 
       <PageSection title={t("roadmap:history.title")} anchorId="history">
-        <HistoryTimeline history={history} t={t} />
+        <HistoryTimeline history={history} />
       </PageSection>
     </div>
   </PageContainer>

--- a/src/pages/resources/tools/accept.astro
+++ b/src/pages/resources/tools/accept.astro
@@ -4,13 +4,11 @@ import ExternalResourceButton from "@/components/ui/ExternalResourceButton.astro
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 import { paymentGateways } from "@/data/monero-tools";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import shieldAlertIcon from "@/assets/icons/mask/shieldAlert.avif";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -20,7 +18,7 @@ const t = await createTInstance(locale);
   <TitleCard
     title={t("tools:accept.title")}
     subtitle={t("tools:accept.subtitle")}
-    backHref={localizeHref(locale, "/resources/tools/")}
+    backHref={localizeHref("/resources/tools/")}
     backLabel={t("tools:index.title")}
   />
 

--- a/src/pages/resources/tools/develop.astro
+++ b/src/pages/resources/tools/develop.astro
@@ -4,13 +4,11 @@ import ExternalResourceButton from "@/components/ui/ExternalResourceButton.astro
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 import { developerLibraries } from "@/data/monero-tools";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import shieldAlertIcon from "@/assets/icons/mask/shieldAlert.avif";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -20,7 +18,7 @@ const t = await createTInstance(locale);
   <TitleCard
     title={t("tools:develop.title")}
     subtitle={t("tools:develop.subtitle")}
-    backHref={localizeHref(locale, "/resources/tools/")}
+    backHref={localizeHref("/resources/tools/")}
     backLabel={t("tools:index.title")}
   />
 

--- a/src/pages/resources/tools/explore.astro
+++ b/src/pages/resources/tools/explore.astro
@@ -5,13 +5,11 @@ import PageContainer from "@/components/ui/PageContainer.astro";
 import PageSection from "@/components/ui/PageSection.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 import { blockExplorers, networkTools, utilities } from "@/data/monero-tools";
-import { createTInstance, getLocale, localizeHref } from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
 import shieldAlertIcon from "@/assets/icons/mask/shieldAlert.avif";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref } = Astro.locals;
 ---
 
 <Layout
@@ -21,7 +19,7 @@ const t = await createTInstance(locale);
   <TitleCard
     title={t("tools:explore.title")}
     subtitle={t("tools:explore.subtitle")}
-    backHref={localizeHref(locale, "/resources/tools/")}
+    backHref={localizeHref("/resources/tools/")}
     backLabel={t("tools:index.title")}
   />
 
@@ -40,7 +38,6 @@ const t = await createTInstance(locale);
                 title={tool.title}
                 subtitle={t(`tools:explore.tools.blockExplorers.${tool.id}`)}
                 onionHref={tool.onionHref}
-                t={t}
               />
             </li>
           ))
@@ -63,7 +60,6 @@ const t = await createTInstance(locale);
                 href={tool.href}
                 title={tool.title}
                 subtitle={t(`tools:explore.tools.network.${tool.id}`)}
-                t={t}
               />
             </li>
           ))
@@ -86,7 +82,6 @@ const t = await createTInstance(locale);
                 href={tool.href}
                 title={tool.title}
                 subtitle={t(`tools:explore.tools.utilities.${tool.id}`)}
-                t={t}
               />
             </li>
           ))

--- a/src/pages/resources/tools/index.astro
+++ b/src/pages/resources/tools/index.astro
@@ -3,40 +3,33 @@ import CategoryCard from "@/components/ui/CategoryCard.astro";
 import PageContainer from "@/components/ui/PageContainer.astro";
 import TitleCard from "@/components/ui/TitleCard.astro";
 import { acceptCount, developCount, exploreCount } from "@/data/monero-tools";
-import {
-  createTInstance,
-  getLocale,
-  localizeHref,
-  localizeNumber,
-} from "@/i18n/utils";
 import Layout from "@/layouts/Layout.astro";
 
-const locale = getLocale(Astro.url);
-const t = await createTInstance(locale);
+const { t, localizeHref, localizeNumber } = Astro.locals;
 
 const categories = [
   {
     title: t("tools:explore.title"),
     description: t("tools:explore.subtitle"),
-    href: localizeHref(locale, "/resources/tools/explore"),
+    href: localizeHref("/resources/tools/explore"),
     linkText: t("tools:index.itemsCount", {
-      num: localizeNumber(locale, exploreCount),
+      num: localizeNumber(exploreCount),
     }),
   },
   {
     title: t("tools:develop.title"),
     description: t("tools:develop.subtitle"),
-    href: localizeHref(locale, "/resources/tools/develop"),
+    href: localizeHref("/resources/tools/develop"),
     linkText: t("tools:index.itemsCount", {
-      num: localizeNumber(locale, developCount),
+      num: localizeNumber(developCount),
     }),
   },
   {
     title: t("tools:accept.title"),
     description: t("tools:accept.subtitle"),
-    href: localizeHref(locale, "/resources/tools/accept"),
+    href: localizeHref("/resources/tools/accept"),
     linkText: t("tools:index.itemsCount", {
-      num: localizeNumber(locale, acceptCount),
+      num: localizeNumber(acceptCount),
     }),
   },
 ];


### PR DESCRIPTION
- refactor localization access to use `Astro.locals` consistently across components
- eliminated needing to pass translation and localization utilities as props
- all components now read t, dir, locale, and helpers directly from `Astro.locals`
- localization helpers from `Astro.locals` no longer require an explicit locale argument - it is pre-seeded with the locale in the middleware