### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.astro
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-alpine AS base
+
+ENV ASTRO_TELEMETRY_DISABLED=1
+RUN corepack enable
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Build the site
+FROM base AS build
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Development server
+FROM base AS dev
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+EXPOSE 4321
+CMD ["pnpm", "dev", "--host"]
+
+# Export static build to host
+FROM scratch AS static
+COPY --from=build /app/dist /
+
+# Serve static build with Caddy
+FROM caddy:alpine AS serve
+COPY --from=build /app/dist /srv
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -51,6 +51,43 @@ All commands are run from the root of the project:
 | `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `pnpm astro -- --help` | Get help using the Astro CLI                     |
 
+## Docker
+
+You can build and run the site without installing Node.js or pnpm. Three targets are available:
+
+| Target   | Purpose                        | Output                  |
+| :------- | :----------------------------- | :---------------------- |
+| `dev`    | Local development, live reload | Dev server on `:4321`   |
+| `static` | Export static site to host     | `dist/` on your machine |
+| `serve`  | Production site via Caddy      | Static server on `:80`  |
+
+### `dev`
+
+```bash
+docker build --target dev -t monero-site-dev .
+docker run -p 4321:4321 -v $(pwd)/src:/app/src monero-site-dev
+```
+
+Then open [http://127.0.0.1:4321](http://127.0.0.1:4321).
+
+### `static`
+
+```bash
+docker build --target static --output dist .
+```
+
+The built site will be output to the `dist/` directory on your host.
+
+### `serve`
+
+```bash
+docker build --target serve -t monero-site .
+docker run -p 8080:80 monero-site
+```
+
+Then open [http://127.0.0.1:8080](http://127.0.0.1:8080).
+
+
 ## More
 
 - [Astro Documentation](https://docs.astro.build)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ docker run -p 8080:80 monero-site
 
 Then open [http://127.0.0.1:8080](http://127.0.0.1:8080).
 
-
 ## More
 
 - [Astro Documentation](https://docs.astro.build)


### PR DESCRIPTION
Add Dockerized build support with five targets

| Target         | Purpose                        | Output                    |
| :------------- | :----------------------------- | :------------------------ |
| `dev`          | Local development, live reload | Dev server on `:4321`     |
| `static`       | Export static site to host     | `dist/` on your machine   |
| `ssr`          | Export SSR build to host       | SSR files on your machine |
| `serve-static` | Production static via Caddy    | Static server on `:80`    |
| `serve-ssr`    | SSR via Node.js (e.g. Coolify) | Node.js server on `:4321` |

- dev:
  ```bash
  docker build --target dev -t monero-site-dev .
  docker run -p 4321:4321 -v $(pwd)/src:/app/src monero-site-dev
  ```
  Hosted on `http://127.0.0.1:4321`
- static:
  ```bash
  docker build --target static --output dist .
  ```
  Static site will be output to `dist`
- ssr:
  ```bash
  docker build --target ssr--output dist-ssr .
  ```
  SSR site will be output to `dist-ssr`. Run command: `node dist-ssr/dist/server/entry.mjs`
- serve-static:
  ```bash
  docker build --target serve-static -t monero-site .
  docker run -p 8080:80 monero-site
  ```
  Available on `http://127.0.0.1:8080`
- serve-ssr:
  ```bash
  docker build --target serve-ssr-t monero-site-ssr .
  docker run -p 4321:4321 monero-site-ssr
  ```
  Available on `http://127.0.0.1:4321`